### PR TITLE
#141

### DIFF
--- a/alf/io.py
+++ b/alf/io.py
@@ -349,7 +349,7 @@ def remove_uuid_file(file_path, dry=False):
     name_parts.pop(-2)
     new_path = file_path.parent.joinpath('.'.join(name_parts))
     if not dry and file_path.exists():
-        file_path.rename(new_path)
+        file_path.replace(new_path)
     return new_path
 
 


### PR DESCRIPTION
Fix for the common error in Windows where ONE functions fail because of `remove_uuid_file`.  The replace method will rename a file even if the path already exists.  The behaviour is identical to `rename` on Unix machines.  `replace` should work on both platforms.