### PR TITLE
Refactoring of ONE and AlyxClient to use singleton pattern for Alyx connection

### DIFF
--- a/alf/io.py
+++ b/alf/io.py
@@ -425,7 +425,7 @@ def _regexp_session_path(path_object, separator):
     """
     Subfunction to be able to test cross-platform
     """
-    return re.search(rf'/\d\d\d\d-\d\d-\d\d/\d\d\d',
+    return re.search(r'/\d\d\d\d-\d\d-\d\d/\d\d\d',
                      str(path_object).replace(separator, '/'), flags=0)
 
 

--- a/ibllib/ephys/ephysqc.py
+++ b/ibllib/ephys/ephysqc.py
@@ -249,7 +249,7 @@ def unit_metrics_ks2(ks2_path=None, m=None, save=True):
 
     if save:
         #  the file name contains the label of the probe (directory name in this case)
-        r.to_csv(ks2_path.joinpath(f'cluster_metrics.csv'))
+        r.to_csv(ks2_path.joinpath('cluster_metrics.csv'))
 
     return r
 

--- a/ibllib/pipes/iblpipe.py
+++ b/ibllib/pipes/iblpipe.py
@@ -266,8 +266,8 @@ def run_task(name, session_dir, dependencies=()):
     return 0
 
 
-def _count(l):
-    return (l)
+def _count(invar):
+    return (invar)
 
 
 class Pipeline:

--- a/oneibl/one.py
+++ b/oneibl/one.py
@@ -104,12 +104,13 @@ class ONE(OneAbstract):
                 self._alyxClient = wc.AlyxClient(username=self._par.ALYX_LOGIN,
                                                  password=self._par.ALYX_PWD,
                                                  base_url=self._par.ALYX_URL)
-                print(f"Connected to {self._par.ALYX_URL} as {self._par.ALYX_LOGIN}",)
             except requests.exceptions.ConnectionError:
                 raise ConnectionError(f"Can't connect to {self._par.ALYX_URL}.\n" +
                                       "IP addresses are filtered on IBL database servers. \n" +
                                       "Are you connecting from an IBL participating institution ?")
             # Init connection to Globus if needed
+        # Display output when instantiating ONE
+        print(f"Connected to {self._par.ALYX_URL} as {self._par.ALYX_LOGIN}",)
 
     @property
     def alyx(self):

--- a/oneibl/one.py
+++ b/oneibl/one.py
@@ -96,19 +96,17 @@ class ONE(OneAbstract):
         self._par = self._par.set('ALYX_URL', base_url or self._par.ALYX_URL)
         self._par = self._par.set('ALYX_PWD', password or self._par.ALYX_PWD)
 
-        # By default set internal AlyxClient to be module singleton object
-        self._alyxClient = wc.alyx_client
-        # If any parameters are enteres create new ALyxClient object
-        if username or password or base_url:
-            try:
-                self._alyxClient = wc.AlyxClient(username=self._par.ALYX_LOGIN,
-                                                 password=self._par.ALYX_PWD,
-                                                 base_url=self._par.ALYX_URL)
-            except requests.exceptions.ConnectionError:
-                raise ConnectionError(f"Can't connect to {self._par.ALYX_URL}.\n" +
-                                      "IP addresses are filtered on IBL database servers. \n" +
-                                      "Are you connecting from an IBL participating institution ?")
-            # Init connection to Globus if needed
+        try:
+            self._alyxClient = wc.AlyxClient(username=self._par.ALYX_LOGIN,
+                                             password=self._par.ALYX_PWD,
+                                             base_url=self._par.ALYX_URL)
+        except requests.exceptions.ConnectionError:
+            raise ConnectionError(
+                f"Can't connect to {self._par.ALYX_URL}.\n" +
+                "IP addresses are filtered on IBL database servers. \n" +
+                "Are you connecting from an IBL participating institution ?"
+            )
+        # Init connection to Globus if needed
         # Display output when instantiating ONE
         if printout:
             print(f"Connected to {self._par.ALYX_URL} as {self._par.ALYX_LOGIN}",)

--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -430,7 +430,7 @@ class AlyxClient:
 
 
 # Get default params from local file
-_par = oneibl.params.get(silent=False)
+_par = oneibl.params.get(silent=True)
 # Try creating singleton AlyxClient object
 try:
     alyx_client = AlyxClient(

--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -177,18 +177,20 @@ def dataset_record_to_url(dataset_record):
 
 
 class UniqueSingletons(type):
-    _instances: dict = {}
+    _instances: list = []
 
     def __call__(cls, *args, **kwargs):
         # print('args', args, '\nkwargs', kwargs)
-        if cls in cls._instances and cls._instances.get(cls, None).get('args') == (args, kwargs):
-            return cls._instances[cls].get('instance')
-        else:
-            cls._instances[cls] = {
-                'args': (args, kwargs),
-                'instance': super(UniqueSingletons, cls).__call__(*args, **kwargs)
-            }
-            return cls._instances[cls].get('instance')
+        for inst in UniqueSingletons._instances:
+            if cls in inst and inst.get(cls, None).get('args') == (args, kwargs):
+                return inst[cls].get('instance')
+
+        new_instance = super(UniqueSingletons, cls).__call__(*args, **kwargs)
+        new_instance_record = {
+            cls: {'args': (args, kwargs), 'instance': new_instance}
+        }
+        UniqueSingletons._instances.append(new_instance_record)
+        return new_instance
 
 
 class AlyxClient(metaclass=UniqueSingletons):

--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import requests
 
 import oneibl.params
+from alf.io import is_uuid_string
 from ibllib.misc import pprint, print_progress
 
 _logger = logging.getLogger('ibllib')
@@ -427,6 +428,146 @@ class AlyxClient:
         elif action == 'update':
             assert(endpoint_scheme[action]['action'] == 'put')
             return self.put('/' + endpoint + '/' + id.split('/')[-1], data=data)
+
+    # JSON field interface convenience methods
+    def _check_inputs(self, endpoint: str, uuid: str) -> None:
+        # make sure the queryied endpoint exists, if not throw an informative error
+        if endpoint not in self._rest_schemes.keys():
+            av = [k for k in self._rest_schemes.keys() if not k.startswith('_') and k]
+            raise ValueError('REST endpoint "' + endpoint + '" does not exist. Available ' +
+                             'endpoints are \n       ' + '\n       '.join(av))
+        # make sure the uuid is a valid UUID4
+        if is_uuid_string(uuid) is False:
+            raise ValueError(f"{uuid} is not a valid uuid")
+        return
+
+    def json_field_write(
+        self,
+        endpoint: str = None,
+        uuid: str = None,
+        field_name: str = None,
+        data: dict = None
+    ) -> dict:
+        """json_field_write [summary]
+        Write data to WILL NOT CHECK IF DATA EXISTS
+        NOTE: Destructive write!
+
+        :param endpoint: Valid alyx endpoint, defaults to None
+        :type endpoint: str, optional
+        :param uuid: Valid uuid sting for a given endpoint, defaults to None
+        :type uuid: str, optional
+        :param field_name: Valid json field name, defaults to None
+        :type field_name: str, optional
+        :param data: data to write to json field, defaults to None
+        :type data: dict, optional
+        :return: Written data dict
+        :rtype: dict
+        """
+        self._check_inputs(endpoint, uuid)
+        # Prepare data to patch
+        patch_dict = {field_name: data}
+        # Upload new extended_qc to session
+        ret = self.rest(endpoint, "partial_update", id=uuid, data=patch_dict)
+        return ret[field_name]
+
+    def json_field_update(
+        self,
+        endpoint: str = None,
+        uuid: str = None,
+        field_name: str = None,
+        data: dict = None
+    ) -> dict:
+        """json_field_update
+        Non destructive update of json field of endpoint for object
+        Will update the field_name of the object with pk = uuid of given endpoint
+        If data has keys with the same name of existing keys it will squash the old
+        values (uses the dict.update() method)
+
+        Example:
+        one.alyx.json_field_update("sessions", "eid_str", "extended_qc" {"key": value})
+
+        :param endpoint: endpoint to hit
+        :type endpoint: str
+        :param uuid: valid uuid of object
+        :type uuid: str
+        :param field_name: name of the json field
+        :type field_name: str
+        :param data: dictionary with fields to be updated
+        :type data: dict
+        :return: new patched json field contents
+        :rtype: dict
+        """
+        self._check_inputs(endpoint, uuid)
+        # Load current json field contents
+        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        if current is None:
+            current = {}
+
+        if not isinstance(current, dict):
+            _logger.warning(
+                f"Current json field {field_name} does not contains a dict, aborting update"
+            )
+            return current
+
+        # Patch current dict with new data
+        current.update(data)
+        # Prepare data to patch
+        patch_dict = {field_name: current}
+        # Upload new extended_qc to session
+        ret = self.rest(endpoint, "partial_update", id=uuid, data=patch_dict)
+        return ret[field_name]
+
+    def json_field_remove_key(
+        self,
+        endpoint: str = None,
+        uuid: str = None,
+        field_name: str = None,
+        key: str = None
+    ) -> dict:
+        """json_field_remove_key
+        Will remove inputted key from json field dict and reupload it to Alyx.
+        Needs endpoint, uuid and json field name
+
+        :param endpoint: endpoint to hit, defaults to None
+        :type endpoint: str, optional
+        :param uuid: valid uuid of endpoint object, defaults to None
+        :type uuid: str, optional
+        :param field_name: json field name of object, defaults to None
+        :type field_name: str, optional
+        :param key: key name of dictionary inside object, defaults to None
+        :type key: str, optional
+        :return: returns new content of json field
+        :rtype: dict
+        """
+        self._check_inputs(endpoint, uuid)
+        current = self.rest(endpoint, "read", id=uuid)[field_name]
+        # If no contents, cannot remove key, return
+        if current is None:
+            return current
+        # if contents are not dict, cannot remove key, return contents
+        if isinstance(current, str):
+            _logger.warning(f"Cannot remove key {key} content of json field is of type str")
+            return current
+        # If key not present in contents of json field cannot remove key, return contents
+        if current.get(key, None) is None:
+            _logger.warning(
+                f"{key}: Key not found in endpoint {endpoint} field {field_name}"
+            )
+            return current
+        _logger.info(f"Removing key from dict: '{key}'")
+        current.pop(key)
+        # Re-write contents without removed key
+        written = self.json_field_write(
+            endpoint=endpoint, uuid=uuid, field_name=field_name, data=current
+        )
+        return written
+
+    def json_field_delete(
+        self, endpoint: str = None, uuid: str = None, field_name: str = None
+    ) -> None:
+        self._check_inputs(endpoint, uuid)
+        _ = self.rest(endpoint, "partial_update", id=uuid, data={field_name: None})
+        return _[field_name]
 
 
 # Get default params from local file

--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -186,10 +186,13 @@ class UniqueSingletons(type):
                 return inst[cls].get('instance')
 
         new_instance = super(UniqueSingletons, cls).__call__(*args, **kwargs)
+        # Optional rerun of constructor
+        # new_instance.__init__(*args, **kwargs)
         new_instance_record = {
             cls: {'args': (args, kwargs), 'instance': new_instance}
         }
         UniqueSingletons._instances.append(new_instance_record)
+
         return new_instance
 
 

--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -436,7 +436,6 @@ try:
     alyx_client = AlyxClient(
         base_url=_par.ALYX_URL, username=_par.ALYX_LOGIN, password=_par.ALYX_PWD
     )
-    print(f"Connected to {_par.ALYX_URL} as {_par.ALYX_LOGIN}",)
 except requests.exceptions.ConnectionError:
     raise ConnectionError(f"Can't connect to {_par.ALYX_URL}.\n" +
                           "IP addresses are filtered on IBL database servers.\n" +

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,5 @@
 ### Release Notes 1.4.15dev - (18/05/2020 - (EDIT THIS HADER BEFORE RELEASE)
--   Implemented AlyxClient as singleton for all ONE instances
+-   Metaclass implementation of UniqueSingletons for AlyxClient
 -   Added JSON methods to AlyxClient
 -   Added get_details method to ONE to retrieve search function deteils after the fact
 -   Refactored one tests, separated utility functions like get_details, path_from_eid, eid_from_path, ...

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,9 @@
+### Release Notes 1.4.15dev - (18/05/2020 - (EDIT THIS HADER BEFORE RELEASE)
+-   Implemented AlyxClient as singleton for all ONE instances
+-   Added JSON methods to AlyxClient
+-   Added get_details method to ONE to retrieve search function deteils after the fact
+-   Refactored one tests, separated utility functions like get_details, path_from_eid, eid_from_path, ...
+
 ### Release Notes 1.4.14 - TBD
 -   Added permutation test, comparing a metric on two sets of datasets, by shuffling labels and seeing how plausible the observed actual difference is
 Sped up calculation of firing_rate

--- a/tests/ibllib/test_io.py
+++ b/tests/ibllib/test_io.py
@@ -188,12 +188,12 @@ class TestSpikeGLX_glob_ephys(unittest.TestCase):
 
         def create_tree(root_dir, dico):
             root_dir.mkdir(exist_ok=True, parents=True)
-            for l in dico:
-                for k in l:
+            for ldir in dico:
+                for k in ldir:
                     if k == 'path' or k == 'label':
                         continue
-                    touchfile(l[k])
-                    Path(l[k]).with_suffix('.meta').touch()
+                    touchfile(ldir[k])
+                    Path(ldir[k]).with_suffix('.meta').touch()
 
         self.tmpdir = Path(tempfile.gettempdir()) / 'test_glob_ephys'
         self.tmpdir.mkdir(exist_ok=True)
@@ -224,7 +224,7 @@ class TestSpikeGLX_glob_ephys(unittest.TestCase):
 
     def test_glob_ephys(self):
         def dict_equals(d1, d2):
-            return all([l in d1 for l in d2]) and all([l in d2 for l in d1])
+            return all([x in d1 for x in d2]) and all([x in d2 for x in d1])
         ef3b = spikeglx.glob_ephys_files(self.dir3b)
         ef3a = spikeglx.glob_ephys_files(self.dir3a)
         # test glob

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -285,7 +285,7 @@ class TestPipesMisc(unittest.TestCase):
         self.assertTrue(alyx_insertion[0]['model'] == '3A')
         self.assertTrue(alyx_insertion[0]['name'] in ['probe00', 'probe01'])
         self.assertTrue(alyx_insertion[1]['model'] == '3A')
-        self.assertTrue(alyx_insertion[1]['name']in ['probe00', 'probe01'])
+        self.assertTrue(alyx_insertion[1]['name'] in ['probe00', 'probe01'])
         # Cleanup DB
         one.alyx.rest('insertions', 'delete', id=alyx_insertion[0]['id'])
         one.alyx.rest('insertions', 'delete', id=alyx_insertion[1]['id'])

--- a/tests/oneibl/test_alyxclient.py
+++ b/tests/oneibl/test_alyxclient.py
@@ -48,14 +48,20 @@ class TestJsonFieldMethods(unittest.TestCase):
         self.eid2_eqc = self.ac.rest(self.endpoint, "read", id=self.eid2)[self.field_name]
 
     def _json_field_write(self):
-        written1 = self.ac.json_field_write(self.endpoint, self.eid1, self.field_name, self.data_dict)
-        written2 = self.ac.json_field_write(self.endpoint, self.eid2, self.field_name, self.data_dict)
+        written1 = self.ac.json_field_write(
+            self.endpoint, self.eid1, self.field_name, self.data_dict
+        )
+        written2 = self.ac.json_field_write(
+            self.endpoint, self.eid2, self.field_name, self.data_dict
+        )
         self.assertTrue(written1 == written2)
         self.assertTrue(written1 == self.data_dict)
         self.assertTrue(len(self.ac.rest(self.endpoint, 'list', extended_qc='some__lt,0.5')) == 2)
 
     def _json_field_update(self):
-        modified = self.ac.json_field_update(self.endpoint, self.eid1,self.field_name, {'some': 0.6})
+        modified = self.ac.json_field_update(
+            self.endpoint, self.eid1, self.field_name, {'some': 0.6}
+        )
         self.assertTrue('data' in modified)
         self.assertTrue('some' in modified)
         self.assertTrue(len(self.ac.rest(self.endpoint, 'list', extended_qc='some__lt,0.5')) == 1)

--- a/tests/oneibl/test_alyxclient.py
+++ b/tests/oneibl/test_alyxclient.py
@@ -25,10 +25,15 @@ class TestSingletonPattern(unittest.TestCase):
             username='test_user',
             password='TapetesBloc18',
             base_url='https://testdev.alyx.internationalbrainlab.org')
+        self.sameac2 = wc.AlyxClient(
+            username='test_user',
+            password='TapetesBloc18',
+            base_url='https://test.alyx.internationalbrainlab.org')
 
     def test_multiple_singletons(self):
         self.assertTrue(id(self.ac) == id(self.sameac))
         self.assertTrue(id(self.ac) != id(self.differentac))
+        self.assertTrue(id(self.ac) == id(self.sameac2))
 
 
 class TestJsonFieldMethods(unittest.TestCase):

--- a/tests/oneibl/test_alyxclient.py
+++ b/tests/oneibl/test_alyxclient.py
@@ -13,12 +13,30 @@ ac = wc.AlyxClient(
     username='test_user', password='TapetesBloc18',
     base_url='https://test.alyx.internationalbrainlab.org')
 
+# Get the singleton AlyxClient from webclient nodule
+sac = wc.alyx_client
+
 
 class TestDownloadHTTP(unittest.TestCase):
 
     def setUp(self):
         self.ac = ac
         self.test_data_uuid = '3ddd45be-7d24-4fc7-9dd3-a98717342af6'
+        self.sac = sac
+
+    def test_singleton_not_instance(self):
+        self.assertTrue(self.sac._obj_id != self.ac._obj_id)
+        # Test reimport
+        import oneibl.webclient as _wc
+        self.assertTrue(_wc.alyx_client._obj_id == self.sac._obj_id)
+        # Test new test instance
+        new_ac = wc.AlyxClient(
+            username='test_user',
+            password='TapetesBloc18',
+            base_url='https://test.alyx.internationalbrainlab.org'
+        )
+        self.assertTrue(new_ac._obj_id != self.ac._obj_id)
+        self.assertTrue(new_ac._obj_id != self.sac._obj_id)
 
     def test_paginated_request(self):
         rep = self.ac.rest('datasets', 'list')

--- a/tests/oneibl/test_alyxclient.py
+++ b/tests/oneibl/test_alyxclient.py
@@ -17,22 +17,18 @@ ac = wc.AlyxClient(
 class TestSingletonPattern(unittest.TestCase):
     def setUp(self):
         self.ac = ac
-        # Get the singleton AlyxClient from webclient nodule
-        self.singleton_ac = wc.alyx_client
-
-    def test_singleton_not_instance(self):
-        self.assertTrue(self.singleton_ac._obj_id != self.ac._obj_id)
-        # Test reimport
-        import oneibl.webclient as _wc
-        self.assertTrue(_wc.alyx_client._obj_id == self.singleton_ac._obj_id)
-        # Test new test instance
-        new_ac = wc.AlyxClient(
+        self.sameac = wc.AlyxClient(
             username='test_user',
             password='TapetesBloc18',
-            base_url='https://test.alyx.internationalbrainlab.org'
-        )
-        self.assertTrue(new_ac._obj_id != self.ac._obj_id)
-        self.assertTrue(new_ac._obj_id != self.singleton_ac._obj_id)
+            base_url='https://test.alyx.internationalbrainlab.org')
+        self.differentac = wc.AlyxClient(
+            username='test_user',
+            password='TapetesBloc18',
+            base_url='https://testdev.alyx.internationalbrainlab.org')
+
+    def test_multiple_singletons(self):
+        self.assertTrue(id(self.ac) == id(self.sameac))
+        self.assertTrue(id(self.ac) != id(self.differentac))
 
 
 class TestJsonFieldMethods(unittest.TestCase):

--- a/tests/oneibl/test_one.py
+++ b/tests/oneibl/test_one.py
@@ -11,6 +11,26 @@ one = ONE(base_url='https://test.alyx.internationalbrainlab.org', username='test
           password='TapetesBloc18')
 
 
+class TestSingletonInstance(unittest.TestCase):
+    def setUp(self):
+        self.one = one
+
+    def test_constructor_differnt_ac(self):
+        # Default behavior should instanciate ONE with the singleton client
+        # Create ONE with no inputs
+        one_default = ONE()
+        self.assertTrue(one_default.alyx._obj_id != self.one.alyx._obj_id)
+        import oneibl.webclient as wc
+        # Test it's the same client
+        self.assertTrue(one_default.alyx._obj_id == wc.alyx_client._obj_id)
+        # Remove real connection to the DB
+        del(one_default)
+        # Test constructor with partial inputs
+        one_partial_in = ONE(base_url='https://test.alyx.internationalbrainlab.org')
+        self.assertTrue(one_partial_in.alyx._obj_id != self.one.alyx._obj_id)
+        self.assertTrue(one_partial_in.alyx._obj_id != wc.alyx_client._obj_id)
+
+
 class TestSearch(unittest.TestCase):
 
     def setUp(self):

--- a/tests/oneibl/test_one.py
+++ b/tests/oneibl/test_one.py
@@ -263,51 +263,5 @@ class TestMisc(unittest.TestCase):
         self.assertEqual(_validate_date_range(val), val)
 
 
-class TestPathsToEidAndBack(unittest.TestCase):
-
-    def setUp(self):
-        # Init connection to the database
-        self.eids = ['cf264653-2deb-44cb-aa84-89b82507028a',
-                     '4e0b3320-47b7-416e-b842-c34dc9004cf8',
-                     'a9d89baf-9905-470c-8565-859ff212c7be',
-                     'aaf101c3-2581-450a-8abd-ddb8f557a5ad',
-                     ]
-        self.partial_eid_paths = [
-            None,
-            None,
-            'FlatIron/mainenlab/Subjects/ZM_1743/2019-06-04/001',
-            'FlatIron/cortexlab/Subjects/KS005/2019-04-04/004',
-        ]
-
-    def test_path_from_eid(self):
-        # Test if eid's produce correct output
-        for e, p in zip(self.eids, self.partial_eid_paths):
-            self.assertTrue(str(p) in str(one.path_from_eid(e)))
-        # Test if list input produces valid list output
-        list_output = one.path_from_eid(self.eids)
-        self.assertTrue(isinstance(list_output, list))
-        self.assertTrue(
-            all([str(p) in str(o) for p, o in zip(self.partial_eid_paths, list_output)])
-        )
-
-    def test_eid_from_path(self):
-        # test if paths produce expected eid's
-        paths = self.partial_eid_paths[-2:]
-        paths.append('FlatIron/mainenlab/Subjects/ZM_1743/2019-06-04/001/bla.ble')
-        paths.append('some/other/root/FlatIron/cortexlab/'
-                     'Subjects/KS005/2019-04-04/004/bli/blo.blu')
-        eids = self.eids[-2:]
-        eids.append('a9d89baf-9905-470c-8565-859ff212c7be')
-        eids.append('aaf101c3-2581-450a-8abd-ddb8f557a5ad')
-        for p, e in zip(paths, eids):
-            self.assertTrue(e == str(one.eid_from_path(p)))
-        # Test if list input produces correct list output
-        list_output = one.eid_from_path(paths)
-        self.assertTrue(isinstance(list_output, list))
-        self.assertTrue(
-            all([e == o for e, o in zip(eids, list_output)])
-        )
-
-
 if __name__ == '__main__':
     unittest.main(exit=False)

--- a/tests/oneibl/test_one.py
+++ b/tests/oneibl/test_one.py
@@ -11,26 +11,6 @@ one = ONE(base_url='https://test.alyx.internationalbrainlab.org', username='test
           password='TapetesBloc18')
 
 
-class TestSingletonInstance(unittest.TestCase):
-    def setUp(self):
-        self.one = one
-
-    def test_constructor_differnt_ac(self):
-        # Default behavior should instanciate ONE with the singleton client
-        # Create ONE with no inputs
-        one_default = ONE()
-        self.assertTrue(one_default.alyx._obj_id != self.one.alyx._obj_id)
-        import oneibl.webclient as wc
-        # Test it's the same client
-        self.assertTrue(one_default.alyx._obj_id == wc.alyx_client._obj_id)
-        # Remove real connection to the DB
-        del(one_default)
-        # Test constructor with partial inputs
-        one_partial_in = ONE(base_url='https://test.alyx.internationalbrainlab.org')
-        self.assertTrue(one_partial_in.alyx._obj_id != self.one.alyx._obj_id)
-        self.assertTrue(one_partial_in.alyx._obj_id != wc.alyx_client._obj_id)
-
-
 class TestSearch(unittest.TestCase):
 
     def setUp(self):

--- a/tests/oneibl/test_oneutils.py
+++ b/tests/oneibl/test_oneutils.py
@@ -1,0 +1,114 @@
+import unittest
+
+from oneibl.one import ONE
+
+one = ONE(
+    base_url="https://test.alyx.internationalbrainlab.org",
+    username="test_user",
+    password="TapetesBloc18",
+)
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        # Init connection to the database
+        self.eids = [
+            "cf264653-2deb-44cb-aa84-89b82507028a",
+            "4e0b3320-47b7-416e-b842-c34dc9004cf8",
+            "a9d89baf-9905-470c-8565-859ff212c7be",
+            "aaf101c3-2581-450a-8abd-ddb8f557a5ad",
+        ]
+        self.partial_eid_paths = [
+            None,
+            None,
+            "FlatIron/mainenlab/Subjects/ZM_1743/2019-06-04/001",
+            "FlatIron/cortexlab/Subjects/KS005/2019-04-04/004",
+        ]
+        self.det_keys = [
+            "subject",
+            "start_time",
+            "number",
+            "lab",
+            "project",
+            "url",
+            "task_protocol",
+            "local_path",
+        ]
+        self.full_det_keys = [
+            "subject",
+            "users",
+            "location",
+            "procedures",
+            "lab",
+            "project",
+            "type",
+            "task_protocol",
+            "number",
+            "start_time",
+            "end_time",
+            "narrative",
+            "parent_session",
+            "n_correct_trials",
+            "n_trials",
+            "url",
+            "extended_qc",
+            "qc",
+            "wateradmin_session_related",
+            "data_dataset_session_related",
+            "json",
+            "probe_insertion",
+        ]
+
+    def test_path_from_eid(self):
+        # Test if eid's produce correct output
+        for e, p in zip(self.eids, self.partial_eid_paths):
+            self.assertTrue(str(p) in str(one.path_from_eid(e)))
+        # Test if list input produces valid list output
+        list_output = one.path_from_eid(self.eids)
+        self.assertTrue(isinstance(list_output, list))
+        self.assertTrue(
+            all([str(p) in str(o) for p, o in zip(self.partial_eid_paths, list_output)])
+        )
+
+    def test_eid_from_path(self):
+        # test if paths produce expected eid's
+        paths = self.partial_eid_paths[-2:]
+        paths.append("FlatIron/mainenlab/Subjects/ZM_1743/2019-06-04/001/bla.ble")
+        paths.append(
+            "some/other/root/FlatIron/cortexlab/" "Subjects/KS005/2019-04-04/004/bli/blo.blu"
+        )
+        eids = self.eids[-2:]
+        eids.append("a9d89baf-9905-470c-8565-859ff212c7be")
+        eids.append("aaf101c3-2581-450a-8abd-ddb8f557a5ad")
+        for p, e in zip(paths, eids):
+            self.assertTrue(e == str(one.eid_from_path(p)))
+        # Test if list input produces correct list output
+        list_output = one.eid_from_path(paths)
+        self.assertTrue(isinstance(list_output, list))
+        self.assertTrue(all([e == o for e, o in zip(eids, list_output)]))
+
+    def test_get_details(self):
+        # Get one known eid details dics
+        det_from_eid = one.get_details(self.eids[0])
+        full_det_from_eid = one.get_details(self.eids[0], full=True)
+        # Test if all keys in returned dict are in expected keys
+        # Full dict output
+        self.assertTrue(
+            all([x in full_det_from_eid for x in self.full_det_keys]),
+            "Missing details key"
+        )
+        # Partial dict output
+        self.assertTrue(
+            all([x in det_from_eid for x in self.det_keys]),
+            "Missing details key"
+        )
+        # Test local path append to details
+        self.assertTrue(det_from_eid['local_path'] is None)
+        # Test is known local_path is not None
+        self.assertTrue(one.get_details(self.eids[2])['local_path'] is not None)
+        # Test list input
+        self.assertTrue(len(self.eids) == len(one.get_details(self.eids)))
+
+
+if __name__ == "__main__":
+    unittest.main(exit=False)


### PR DESCRIPTION
Here it is, I copied my slack post here:

> By definition singletons allow only one instance do this would create a problem if we'd need to two of them e.g. an ONE obj that connects to the dev and another that connects to the test DB. Coincidentally modules in python are all singleton objects, this means that importing any module multiple times means importing it only once, this is apparent when importing module you are developing then changing a couple of lines and having to close tje python interpreter to access the changes as reimporting it does not really reimport it.
> No changes in the AlyxClient itself, just the addition of the import oneibl.params at the top to be able to create the singleton object at the end of the webclient module.
> ```python
> # Get default params from local file
> _par = oneibl.params.get(silent=False)
> # Try creating singleton AlyxClient object
> try:
>     alyx_client = AlyxClient(base_url=_par.ALYX_URL, username=_par.ALYX_LOGIN, password=_par.ALYX_PWD)
>     print('Connected to ' + _par.ALYX_URL + ' as ' + _par.ALYX_LOGIN,)
> except requests.exceptions.ConnectionError:
>     raise ConnectionError("Can't connect to " + _par.ALYX_URL + '. \n' +
>                             'IP addresses are filtered on IBL database servers. \n' +
>                             'Are you connecting from an IBL participating institution ?')
> # Init connection to Globus if needed
> 
> ```

> So now the first time anyone imports the webclient module in any of the possible import patterns that exist in python, the singleton gets instantiated  with the "default" params, i.e. using username/password/base_url from the params file.

> 
> I added a new AlyxClient instance param `self._obj_id = id(self)` for testing.
> Interface with AlyxClient is exactly the same, i.e if you want your own AlyxClient just import the class and make an instance as usual.
> The webclient module now has an extra thing you can import from it:
> `from oneibl.webclient import alyx_client`  This is the singleton object.
> All previous tests pass, and I'm writing the tests for making sure that the id of the singleton is reused in the user case and its new in the dev cases  (when AlyxClient or the ONE object instances have ben initiated with any username/password/base_url param
> in ONE the changes are also minimal:
> ```python
> class ONE(OneAbstract):
>     def __init__(self, username=None, password=None, base_url=None, silent=False):
>         # get parameters override if inputs provided
>         self._par = oneibl.params.get(silent=silent)
>         self._par = self._par.set('ALYX_LOGIN', username or self._par.ALYX_LOGIN)
>         self._par = self._par.set('ALYX_URL', base_url or self._par.ALYX_URL)
>         self._par = self._par.set('ALYX_PWD', password or self._par.ALYX_PWD)
>         # By default set internal AlyxClient is the module singleton object
>         self._alyxClient = wc.alyx_client
>         # If any parameters are entered create new ALyxClient object
>         if username or password or base_url:
>             try:
>                 self._alyxClient = wc.AlyxClient(username=self._par.ALYX_LOGIN,
>                                                  password=self._par.ALYX_PWD,
>                                                  base_url=self._par.ALYX_URL)
>                 print('Connected to ' + self._par.ALYX_URL + ' as ' + self._par.ALYX_LOGIN,)
>             except requests.exceptions.ConnectionError:
>                 raise ConnectionError("Can't connect to " + self._par.ALYX_URL + '. \n' +
>                                     'IP addresses are filtered on IBL database servers. \n' +
>                                     'Are you connecting from an IBL participating institution ?')
>             # Init connection to Globus if needed
>     @property
>     def alyx(self):
>         return self._alyxClient
> ```
> I removed my previous implementation and basically I now just create the ONE instance AlyxClient by pointing to the singleton in the module. So now all instances of ONE will point to the same singleton object.
> If one however passes any of the input parameters username/password/base_url when instantiating ONE the ONE instance will create a new AlyxClient with the provided params.
> 