### PR TITLE
Partial raw data download via HTTP content range

### DIFF
--- a/oneibl/webclient.py
+++ b/oneibl/webclient.py
@@ -21,6 +21,7 @@ class _PaginatedResponse(Mapping):
     Provides cache functionality
     PaginatedResponse(alyx, response)
     """
+
     def __init__(self, alyx, rep):
         self.alyx = alyx
         self.count = rep['count']
@@ -68,7 +69,7 @@ def http_download_file_list(links_to_file_list, **kwargs):
     return file_names_list
 
 
-def http_download_file(full_link_to_file, *, clobber=False, offline=False,
+def http_download_file(full_link_to_file, chunks=None, *, clobber=False, offline=False,
                        username='', password='', cache_dir='', return_md5=False):
     """
     :param full_link_to_file: http link to the file.
@@ -117,9 +118,15 @@ def http_download_file(full_link_to_file, *, clobber=False, offline=False,
     opener = urllib.request.build_opener(auth)
     urllib.request.install_opener(opener)
 
+    # Support for partial download.
+    req = urllib.request.Request(full_link_to_file)
+    if chunks is not None:
+        first_byte, n_bytes = chunks
+        req.add_header("Range", "bytes=%d-%d" % (first_byte, first_byte + n_bytes - 1))
+
     # Open the url and get the length
     try:
-        u = urllib.request.urlopen(full_link_to_file)
+        u = urllib.request.urlopen(req)
     except urllib.error.HTTPError as e:
         _logger.error(f"{str(e)} {full_link_to_file}")
         raise e


### PR DESCRIPTION
Test with:

```python
from oneibl.one import ONE
o = ONE()
arr = o.download_raw_partial(
'http://ibl.flatironinstitute.org/hoferlab/Subjects/SWC_043/2020-09-23/001/raw_ephys_data/probe00/_spikeglx_ephysData_g0_t0.imec0.ap.e9fabe60-2075-41af-ba5a-b126ca965f88.cbin',
'http://ibl.flatironinstitute.org/hoferlab/Subjects/SWC_043/2020-09-23/001/raw_ephys_data/probe00/_spikeglx_ephysData_g0_t0.imec0.ap.8f81ad37-a9ea-4406-9de4-46531d83374b.ch',
10, 13)
print(arr)
```