### PR TITLE
Feature/server scripts

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 99
-ignore = W504, E266
+ignore = W504, W503, E266
 exclude =
     .git,
     __pycache__,

--- a/ibllib/pipes/scan_fix_passive_files.py
+++ b/ibllib/pipes/scan_fix_passive_files.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+# @Author: Niccolò Bonacchi
+# @Date: Thursday, September 24th 2020, 2:10:29 pm
+import json
+import logging
+import shutil
+from pathlib import Path, PureWindowsPath
+
+from alf.folders import session_path
+
+log = logging.getLogger("ibllib")
+
+
+def load_settings_file(filepath, key=None):
+    filepath = Path(filepath)
+    if filepath.stat().st_size == 0:
+        return
+
+    with open(filepath, "r") as f:
+        settings = json.load(f)
+    return settings.get(key, None) if key else settings
+
+
+def find_pairs(root_data_folder):
+    """Find all passive sessions that needs transfer and where to"""
+    root_data_folder = Path(root_data_folder)
+    settings_files = list(root_data_folder.rglob("_iblrig_taskSettings.raw.json"))
+    pairs = []
+    # Load the corresponding ephys session path form settings file if exists
+    for sf in settings_files:
+        # Get session path form settings file
+        source_spath = session_path(sf)
+        # Find the root_data_path for session
+        subjects_folder_path = Path(*Path(source_spath).parts[:-3])
+        # Load reference to corresponding ephys session (ces) which comes in windows format
+        ces = load_settings_file(sf, key="CORRESPONDING_EPHYS_SESSION")
+        # if CORRESPONDING_EPHYS_SESSION does not exist, it's not a passive session
+        if ces is None:
+            continue
+        # Convert windows path to corresponsding session name (csn) in native Path format
+        csn = Path(*PureWindowsPath(ces).parts[-3:])
+        target_spath = str(subjects_folder_path / csn)
+
+        pairs.append((source_spath, target_spath))
+    # Remove sessions that are already transfered i.e. source and destination files are ==
+    from_to_pairs = [(x, y) for x, y in pairs if x != y]
+    log.info(f"Found {len(from_to_pairs)} passive sessions to move")
+    return from_to_pairs
+
+
+def move_rename_pairs(from_to_pairs):
+    """"""
+    moved_ok = []
+    for i, (src, dst) in enumerate(from_to_pairs):
+        src = Path(src)
+        dst = Path(dst)
+        log.info(f"Moving {i+1} of {len(from_to_pairs)}: \n{src}\n--> {dst}")
+        try:
+            shutil.move(str(src / "raw_behavior_data"), str(dst / "raw_passive_data"))
+            ffile = src.joinpath("passive_data_for_ephys.flag")
+            if ffile.exists():
+                ffile.unlink()
+                ffile.parent.rmdir()
+            moved_ok.append(True)
+        except BaseException as e:
+            log.error(f"Failed to move {src} to {dst}:\n {e}")
+            moved_ok.append(False)
+            continue
+    log.info(f"Moved {sum(moved_ok)} of {len(from_to_pairs)}")
+    return moved_ok
+
+
+def execute(root_data_folder):
+    from_to_pairs = find_pairs(root_data_folder)
+    moved_ok = move_rename_pairs(from_to_pairs)
+    return from_to_pairs, moved_ok
+
+
+if __name__ == "__main__":
+    pass
+    # TODO: implement command line interface

--- a/ibllib/pipes/scan_fix_passive_files.py
+++ b/ibllib/pipes/scan_fix_passive_files.py
@@ -26,11 +26,14 @@ def find_pairs(root_data_folder):
     """Find all passive sessions that needs transfer and where to"""
     root_data_folder = Path(root_data_folder)
     settings_files = list(root_data_folder.rglob("_iblrig_taskSettings.raw.json"))
+    log.info(f"Found {len(settings_files)} sessions")
     pairs = []
     # Load the corresponding ephys session path form settings file if exists
     for sf in settings_files:
         # Get session path form settings file
         source_spath = session_path(sf)
+        if source_spath is None:
+            continue
         # Find the root_data_path for session
         subjects_folder_path = Path(*Path(source_spath).parts[:-3])
         # Load reference to corresponding ephys session (ces) which comes in windows format
@@ -71,12 +74,15 @@ def move_rename_pairs(from_to_pairs):
     return moved_ok
 
 
-def execute(root_data_folder):
+def execute(root_data_folder, dry=True):
     from_to_pairs = find_pairs(root_data_folder)
+    if dry:
+        return from_to_pairs, [False for x in from_to_pairs]
     moved_ok = move_rename_pairs(from_to_pairs)
     return from_to_pairs, moved_ok
 
 
 if __name__ == "__main__":
-    pass
+    root_data_folder = '/home/nico/Downloads/FlatIron'
+    from_to_pairs = find_pairs(root_data_folder)
     # TODO: implement command line interface

--- a/ibllib/pipes/scan_fix_passive_files.py
+++ b/ibllib/pipes/scan_fix_passive_files.py
@@ -90,9 +90,3 @@ def execute(root_data_folder, dry=True):
         return from_to_pairs, [False for x in from_to_pairs]
     moved_ok = move_rename_pairs(from_to_pairs)
     return from_to_pairs, moved_ok
-
-
-if __name__ == "__main__":
-    root_data_folder = '/home/nico/Downloads/FlatIron'
-    from_to_pairs = find_pairs(root_data_folder)
-    # TODO: implement command line interface

--- a/ibllib/pipes/scan_fix_passive_files.py
+++ b/ibllib/pipes/scan_fix_passive_files.py
@@ -26,9 +26,14 @@ def find_pairs(root_data_folder):
     """Find all passive sessions that needs transfer and where to"""
     root_data_folder = Path(root_data_folder)
     settings_files = list(root_data_folder.rglob("_iblrig_taskSettings.raw.json"))
-    log.info(f"Found {len(settings_files)} sessions")
-    pairs = []
+    n_settings_files = len(settings_files)
+    if n_settings_files == 0:
+        log.warning(f"Found {n_settings_files} sessions")
+    else:
+        log.info(f"Found {n_settings_files} sessions")
+
     # Load the corresponding ephys session path form settings file if exists
+    pairs = []
     for sf in settings_files:
         # Get session path form settings file
         source_spath = session_path(sf)
@@ -48,7 +53,12 @@ def find_pairs(root_data_folder):
         pairs.append((source_spath, target_spath))
     # Remove sessions that are already transfered i.e. source and destination files are ==
     from_to_pairs = [(x, y) for x, y in pairs if x != y]
-    log.info(f"Found {len(from_to_pairs)} passive sessions to move")
+    n_pairs = len(from_to_pairs)
+    if n_pairs == 0:
+        log.warning(f"Found {n_pairs} passive sessions to move")
+    else:
+        log.info(f"Found {n_pairs} passive sessions to move")
+
     return from_to_pairs
 
 

--- a/tests/ibllib/fixtures/utils.py
+++ b/tests/ibllib/fixtures/utils.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+# @Author: Niccolò Bonacchi
+# @Date: Friday, October 9th 2020, 12:02:56 pm
+import json
+from pathlib import Path
+
+
+def create_fake_session_folder(
+    root_data_path, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="001", increment=True
+):
+    root_data_path = Path(root_data_path)
+    session_path = root_data_path / lab / "Subjects" / mouse / date / num
+    if session_path.exists() and increment:
+        num = str(int(num) + 1).zfill(3)
+        return create_fake_session_folder(
+            root_data_path, lab=lab, mouse=mouse, date=date, num=num, increment=increment
+        )
+    session_path = root_data_path / lab / "Subjects" / mouse / date / num
+
+    session_path.mkdir(exist_ok=True, parents=True)
+    return session_path
+
+
+def create_fake_raw_ephys_data_folder(session_path, populate=True):
+    """create_fake_raw_ephys_data_folder creates raw_ephys_data folder
+    can populate with empty files with expected names
+
+    :param session_path: [description]
+    :type session_path: [type]
+    :param populate: [description], defaults to True
+    :type populate: bool, optional
+    :return: [description]
+    :rtype: [type]
+    """
+    session_path = Path(session_path)
+    raw_ephys_data_path = session_path / "raw_ephys_data"
+    raw_ephys_data_path.mkdir(exist_ok=True, parents=True)
+    if populate:
+        file_list = [
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.sync.npy",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.lf.meta",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.ap.cbin",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.timestamps.npy",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.lf.cbin",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.ap.ch",
+            "probe00/_spikeglx_ephysData_g0_t0.imec0.wiring.json",
+            "probe00/_spikeglx_sync.times.probe00.npy",
+            "probe00/_spikeglx_sync.channels.probe00.npy",
+            "probe00/_spikeglx_sync.polarities.probe00.npy",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.sync.npy",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.lf.meta",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.timestamps.cbin",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.ap.cbin",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.lf.cbin",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.ap.ch",
+            "probe01/_spikeglx_ephysData_g0_t0.imec1.wiring.json",
+            "_spikeglx_ephysData_g0_t0.nidq.sync.npy",
+            "_spikeglx_ephysData_g0_t0.nidq.meta",
+            "_spikeglx_ephysData_g0_t0.nidq.cbin",
+            "_spikeglx_ephysData_g0_t0.nidq.ch",
+            "_spikeglx_ephysData_g0_t0.wiring.json",
+        ]
+        for f in file_list:
+            fpath = raw_ephys_data_path / Path(f)
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.touch()
+
+    return session_path
+
+
+def create_fake_raw_video_data_folder(session_path, populate=True):
+    session_path = Path(session_path)
+    raw_video_data_path = session_path / "raw_video_data"
+    raw_video_data_path.mkdir(exist_ok=True, parents=True)
+    if populate:
+        file_list = [
+            "_iblrig_leftCamera.raw.mp4",
+            "_iblrig_rightCamera.raw.mp4",
+            "_iblrig_bodyCamera.raw.mp4",
+            "_iblrig_leftCamera.timestamps.ssv",
+            "_iblrig_rightCamera.timestamps.ssv",
+            "_iblrig_bodyCamera.timestamps.ssv",
+            "_iblrig_leftCamera.GPIO.bin",
+            "_iblrig_rightCamera.GPIO.bin",
+            "_iblrig_bodyCamera.GPIO.bin",
+            "_iblrig_leftCamera.frame_counter.bin",
+            "_iblrig_rightCamera.frame_counter.bin",
+            "_iblrig_bodyCamera.frame_counter.bin",
+            "_iblrig_VideoCodeFiles.raw.zip",
+        ]
+        for f in file_list:
+            fpath = raw_video_data_path / Path(f)
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.touch()
+
+
+def create_fake_raw_behavior_data_folder(
+    session_path, populate=True, task="ephysCW", folder="raw_behavior_data"
+):
+    raw_behavior_data_path = session_path / folder
+    raw_behavior_data_path.mkdir(exist_ok=True, parents=True)
+    ephysCW = [
+        "_iblrig_ambientSensorData.raw.jsonable",
+        "_iblrig_encoderEvents.raw.ssv",
+        "_iblrig_encoderPositions.raw.ssv",
+        "_iblrig_encoderTrialInfo.raw.ssv",
+        "_iblrig_micData.raw.wav",
+        "_iblrig_stimPositionScreen.raw.csv",
+        "_iblrig_syncSquareUpdate.raw.csv",
+        "_iblrig_taskCodeFiles.raw.zip",
+        "_iblrig_taskData.raw.jsonable",
+        "_iblrig_taskSettings.raw.json",
+        "online_plot.png",
+    ]
+    passiveCW = [
+        "_iblrig_encoderEvents.raw.ssv",
+        "_iblrig_encoderPositions.raw.ssv",
+        "_iblrig_encoderTrialInfo.raw.ssv",
+        "_iblrig_RFMapStim.raw.bin",
+        "_iblrig_stimPositionScreen.raw.csv",
+        "_iblrig_syncSquareUpdate.raw.csv",
+        "_iblrig_taskCodeFiles.raw.zip",
+        "_iblrig_taskSettings.raw.json",
+    ]
+
+    if populate:
+        file_list = []
+        if "ephys" in task:
+            file_list = ephysCW
+        elif "passive" in task:
+            file_list = passiveCW
+            (session_path / "passive_data_for_ephys.flag").touch()
+        else:
+            print(f"Not implemented: Task {task}")
+
+        for f in file_list:
+            fpath = raw_behavior_data_path / Path(f)
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.touch()
+
+    return session_path
+
+
+def populate_task_settings(fpath: Path, patch: dict):
+    with fpath.open("w") as f:
+        json.dump(patch, f, indent=1)
+
+
+def create_fake_complete_ephys_session(
+    root_data_path, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="001", increment=True
+):
+    session_path = create_fake_session_folder(
+        root_data_path, lab=lab, mouse=mouse, date=date, num=num, increment=increment
+    )
+    _mouse, _date, _num = session_path.parts[-3:]
+    create_fake_raw_ephys_data_folder(session_path, populate=True)
+    create_fake_raw_video_data_folder(session_path, populate=True)
+    create_fake_raw_behavior_data_folder(session_path, populate=True, task="ephys")
+    create_fake_raw_behavior_data_folder(
+        session_path, populate=True, task="passive", folder="raw_passive_data"
+    )
+    fpath = Path(session_path) / "raw_passive_data" / "_iblrig_taskSettings.raw.json"
+    passive_settings = {
+        "CORRESPONDING_EPHYS_SESSION": f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
+    }
+    populate_task_settings(fpath, passive_settings)
+    if session_path.joinpath("passive_data_for_ephys.flag").exists():
+        session_path.joinpath("passive_data_for_ephys.flag").unlink()
+
+    return session_path
+
+
+def create_fake_ephys_recording_bad_passive_transfer_sessions(
+    root_data_path, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="001", increment=True
+):
+    session_path = create_fake_session_folder(
+        root_data_path, lab=lab, mouse=mouse, date=date, num=num, increment=increment
+    )
+    _mouse, _date, _num = session_path.parts[-3:]
+    create_fake_raw_ephys_data_folder(session_path, populate=True)
+    create_fake_raw_video_data_folder(session_path, populate=True)
+    create_fake_raw_behavior_data_folder(session_path, populate=True, task="ephys")
+
+    passive_session_path = create_fake_session_folder(
+        root_data_path, lab=lab, mouse=mouse, date=date, num=num, increment=increment
+    )
+    create_fake_raw_behavior_data_folder(passive_session_path, populate=True, task="passive")
+    fpath = Path(passive_session_path) / "raw_behavior_data" / "_iblrig_taskSettings.raw.json"
+    passive_settings = {
+        "CORRESPONDING_EPHYS_SESSION": f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
+    }
+    populate_task_settings(fpath, passive_settings)
+
+    return session_path, passive_session_path
+
+
+if __name__ == "__main__":
+    pass
+    # root_data_path = "/home/nico/Projects/IBL/scratch/serverpc/_mnt_s0_Data"
+    # # Create a fake ephys session
+    # session_path = create_fake_session_folder(
+    #     root_data_path, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="001"
+    # )
+    # create_fake_raw_ephys_data_folder(session_path, populate=True)
+    # create_fake_raw_video_data_folder(session_path, populate=True)
+    # create_fake_raw_behavior_data_folder(session_path, populate=True, task="ephys")
+    # # create a fake passive session that was not transferred
+    # passive_session_path = create_fake_session_folder(
+    #     root_data_path, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="002"
+    # )
+    # create_fake_raw_behavior_data_folder(passive_session_path, populate=True, task="passive")
+
+    # fpath = Path(passive_session_path) / "raw_behavior_data" / "_iblrig_taskSettings.raw.json"
+    # passive_settings = {"CORRESPONDING_EPHYS_SESSION": str(session_path)}
+    # populate_task_settings(fpath, passive_settings)

--- a/tests/ibllib/fixtures/utils.py
+++ b/tests/ibllib/fixtures/utils.py
@@ -162,7 +162,8 @@ def create_fake_complete_ephys_session(
     )
     fpath = Path(session_path) / "raw_passive_data" / "_iblrig_taskSettings.raw.json"
     passive_settings = {
-        "CORRESPONDING_EPHYS_SESSION": f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
+        "CORRESPONDING_EPHYS_SESSION":
+            f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
     }
     populate_task_settings(fpath, passive_settings)
     if session_path.joinpath("passive_data_for_ephys.flag").exists():
@@ -188,7 +189,8 @@ def create_fake_ephys_recording_bad_passive_transfer_sessions(
     create_fake_raw_behavior_data_folder(passive_session_path, populate=True, task="passive")
     fpath = Path(passive_session_path) / "raw_behavior_data" / "_iblrig_taskSettings.raw.json"
     passive_settings = {
-        "CORRESPONDING_EPHYS_SESSION": f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
+        "CORRESPONDING_EPHYS_SESSION":
+            f"C:\\some\\root\\folder\\Subjects\\{_mouse}\\{_date}\\{_num}"
     }
     populate_task_settings(fpath, passive_settings)
 

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -4,27 +4,28 @@ import unittest
 from pathlib import Path
 
 import ibllib.io.raw_data_loaders as rawio
+import tests.ibllib.fixtures.utils as fu
 from ibllib.pipes import misc
 from oneibl.one import ONE
+import ibllib.pipes.scan_fix_passive_files as fix
 
 
 class TestExtractors(unittest.TestCase):
-
     def test_task_names_extractors(self):
         """
         This is to test against regressions
         """
         task_out = [
-            ('_iblrig_tasks_biasedChoiceWorld3.7.0', 'biased'),
-            ('_iblrig_tasks_biasedScanningChoiceWorld5.2.3', 'biased'),
-            ('_iblrig_tasks_trainingChoiceWorld3.6.0', 'training'),
-            ('_iblrig_tasks_ephysChoiceWorld5.1.3', 'ephys'),
-            ('_iblrig_calibration_frame2TTL4.1.3', None),
-            ('_iblrig_tasks_habituationChoiceWorld3.6.0', 'habituation'),
-            ('_iblrig_tasks_scanningOptoChoiceWorld5.0.0', None),
-            ('_iblrig_tasks_RewardChoiceWorld4.1.3', None),
-            ('_iblrig_calibration_screen4.1.3', None),
-            ('_iblrig_tasks_ephys_certification4.1.3', 'sync_ephys'),
+            ("_iblrig_tasks_biasedChoiceWorld3.7.0", "biased"),
+            ("_iblrig_tasks_biasedScanningChoiceWorld5.2.3", "biased"),
+            ("_iblrig_tasks_trainingChoiceWorld3.6.0", "training"),
+            ("_iblrig_tasks_ephysChoiceWorld5.1.3", "ephys"),
+            ("_iblrig_calibration_frame2TTL4.1.3", None),
+            ("_iblrig_tasks_habituationChoiceWorld3.6.0", "habituation"),
+            ("_iblrig_tasks_scanningOptoChoiceWorld5.0.0", None),
+            ("_iblrig_tasks_RewardChoiceWorld4.1.3", None),
+            ("_iblrig_calibration_screen4.1.3", None),
+            ("_iblrig_tasks_ephys_certification4.1.3", "sync_ephys"),
         ]
         for to in task_out:
             out = rawio.get_task_extractor_type(to[0])
@@ -32,35 +33,32 @@ class TestExtractors(unittest.TestCase):
 
 
 class TestPipesMisc(unittest.TestCase):
-    """
-    """
+    """"""
 
     def setUp(self):
         # Define folders
-        self.root_test_folder = Path(tempfile.gettempdir()) / 'ibllib_test'
-        self.local_data_path = self.root_test_folder / 'local' / 'iblrig_data' / 'Subjects'
-        self.remote_data_path = self.root_test_folder / 'remote' / 'iblrig_data' / 'Subjects'
-        self.local_session_path_3A = self.local_data_path / \
-            'test_subject' / '1900-01-01' / '001'
-        self.local_session_path_3B = self.local_data_path / \
-            'test_subject' / '1900-01-02' / '001'
-        self.raw_ephys_data_path_3A = self.local_session_path_3A / 'raw_ephys_data'
-        self.raw_ephys_data_path_3B = self.local_session_path_3B / 'raw_ephys_data'
-        self.probe00_path_3A = self.raw_ephys_data_path_3A / 'probe00'
-        self.probe01_path_3A = self.raw_ephys_data_path_3A / 'probe01'
-        self.probe00_path_3B = self.raw_ephys_data_path_3B / 'probe00'
-        self.probe01_path_3B = self.raw_ephys_data_path_3B / 'probe01'
+        self.root_test_folder = Path(tempfile.gettempdir()) / "ibllib_test"
+        self.local_data_path = self.root_test_folder / "local" / "iblrig_data" / "Subjects"
+        self.remote_data_path = self.root_test_folder / "remote" / "iblrig_data" / "Subjects"
+        self.local_session_path_3A = self.local_data_path / "test_subject" / "1900-01-01" / "001"
+        self.local_session_path_3B = self.local_data_path / "test_subject" / "1900-01-02" / "001"
+        self.raw_ephys_data_path_3A = self.local_session_path_3A / "raw_ephys_data"
+        self.raw_ephys_data_path_3B = self.local_session_path_3B / "raw_ephys_data"
+        self.probe00_path_3A = self.raw_ephys_data_path_3A / "probe00"
+        self.probe01_path_3A = self.raw_ephys_data_path_3A / "probe01"
+        self.probe00_path_3B = self.raw_ephys_data_path_3B / "probe00"
+        self.probe01_path_3B = self.raw_ephys_data_path_3B / "probe01"
 
-        self.bad_ephys_folder_3A = self.raw_ephys_data_path_3A / 'bad_ephys_folder'
-        self.bad_probe00_folder_3A = self.bad_ephys_folder_3A / 'some_probe00_folder'
-        self.bad_probe01_folder_3A = self.bad_ephys_folder_3A / 'some_probe01_folder'
+        self.bad_ephys_folder_3A = self.raw_ephys_data_path_3A / "bad_ephys_folder"
+        self.bad_probe00_folder_3A = self.bad_ephys_folder_3A / "some_probe00_folder"
+        self.bad_probe01_folder_3A = self.bad_ephys_folder_3A / "some_probe01_folder"
 
-        self.bad_ephys_folder_3B = self.raw_ephys_data_path_3B / 'bad_folder_g0_t0'
-        self.bad_probe00_folder_3B = self.bad_ephys_folder_3B / 'bad_folder_g0_t0.imec0'
-        self.bad_probe01_folder_3B = self.bad_ephys_folder_3B / 'bad_folder_g0_t0.imec1'
+        self.bad_ephys_folder_3B = self.raw_ephys_data_path_3B / "bad_folder_g0_t0"
+        self.bad_probe00_folder_3B = self.bad_ephys_folder_3B / "bad_folder_g0_t0.imec0"
+        self.bad_probe01_folder_3B = self.bad_ephys_folder_3B / "bad_folder_g0_t0.imec1"
         # Make folders
-        (self.local_session_path_3A / 'raw_behavior_data').mkdir(exist_ok=True, parents=True)
-        (self.local_session_path_3B / 'raw_behavior_data').mkdir(exist_ok=True, parents=True)
+        (self.local_session_path_3A / "raw_behavior_data").mkdir(exist_ok=True, parents=True)
+        (self.local_session_path_3B / "raw_behavior_data").mkdir(exist_ok=True, parents=True)
         self.probe00_path_3A.mkdir(exist_ok=True, parents=True)
         self.probe00_path_3B.mkdir(exist_ok=True, parents=True)
         self.probe01_path_3A.mkdir(exist_ok=True, parents=True)
@@ -75,32 +73,32 @@ class TestPipesMisc(unittest.TestCase):
 
     def populate_bad_folders(self):
         # 3A
-        (self.bad_probe00_folder_3A / 'blabla_g0_t0.imec.ap.bin').touch()
-        (self.bad_probe00_folder_3A / 'blabla_g0_t0.imec.lf.bin').touch()
-        (self.bad_probe00_folder_3A / 'blabla_g0_t0.imec.ap.meta').touch()
-        (self.bad_probe00_folder_3A / 'blabla_g0_t0.imec.lf.meta').touch()
+        (self.bad_probe00_folder_3A / "blabla_g0_t0.imec.ap.bin").touch()
+        (self.bad_probe00_folder_3A / "blabla_g0_t0.imec.lf.bin").touch()
+        (self.bad_probe00_folder_3A / "blabla_g0_t0.imec.ap.meta").touch()
+        (self.bad_probe00_folder_3A / "blabla_g0_t0.imec.lf.meta").touch()
 
-        (self.bad_probe01_folder_3A / 'blabla_g0_t0.imec.ap.bin').touch()
-        (self.bad_probe01_folder_3A / 'blabla_g0_t0.imec.lf.bin').touch()
-        (self.bad_probe01_folder_3A / 'blabla_g0_t0.imec.ap.meta').touch()
-        (self.bad_probe01_folder_3A / 'blabla_g0_t0.imec.lf.meta').touch()
+        (self.bad_probe01_folder_3A / "blabla_g0_t0.imec.ap.bin").touch()
+        (self.bad_probe01_folder_3A / "blabla_g0_t0.imec.lf.bin").touch()
+        (self.bad_probe01_folder_3A / "blabla_g0_t0.imec.ap.meta").touch()
+        (self.bad_probe01_folder_3A / "blabla_g0_t0.imec.lf.meta").touch()
         # 3B
-        (self.bad_probe00_folder_3B / 'blabla_g0_t0.imec0.ap.bin').touch()
-        (self.bad_probe00_folder_3B / 'blabla_g0_t0.imec0.lf.bin').touch()
-        (self.bad_probe00_folder_3B / 'blabla_g0_t0.imec0.ap.meta').touch()
-        (self.bad_probe00_folder_3B / 'blabla_g0_t0.imec0.lf.meta').touch()
+        (self.bad_probe00_folder_3B / "blabla_g0_t0.imec0.ap.bin").touch()
+        (self.bad_probe00_folder_3B / "blabla_g0_t0.imec0.lf.bin").touch()
+        (self.bad_probe00_folder_3B / "blabla_g0_t0.imec0.ap.meta").touch()
+        (self.bad_probe00_folder_3B / "blabla_g0_t0.imec0.lf.meta").touch()
 
-        (self.bad_probe01_folder_3B / 'blabla_g0_t0.imec1.ap.bin').touch()
-        (self.bad_probe01_folder_3B / 'blabla_g0_t0.imec1.lf.bin').touch()
-        (self.bad_probe01_folder_3B / 'blabla_g0_t0.imec1.ap.meta').touch()
-        (self.bad_probe01_folder_3B / 'blabla_g0_t0.imec1.lf.meta').touch()
+        (self.bad_probe01_folder_3B / "blabla_g0_t0.imec1.ap.bin").touch()
+        (self.bad_probe01_folder_3B / "blabla_g0_t0.imec1.lf.bin").touch()
+        (self.bad_probe01_folder_3B / "blabla_g0_t0.imec1.ap.meta").touch()
+        (self.bad_probe01_folder_3B / "blabla_g0_t0.imec1.lf.meta").touch()
 
-        (self.bad_ephys_folder_3B / 'blabla_g0_t0.nidq.bin').touch()
-        (self.bad_ephys_folder_3B / 'blabla_g0_t0.nidq.meta').touch()
+        (self.bad_ephys_folder_3B / "blabla_g0_t0.nidq.bin").touch()
+        (self.bad_ephys_folder_3B / "blabla_g0_t0.nidq.meta").touch()
 
     def test_behavior_exists(self):
-        assert(misc.behavior_exists('.') is False)
-        assert(misc.behavior_exists(self.local_session_path_3A) is True)
+        assert misc.behavior_exists(".") is False
+        assert misc.behavior_exists(self.local_session_path_3A) is True
 
     def test_check_transfer(self):
         misc.check_transfer(self.bad_probe00_folder_3A, self.bad_probe00_folder_3A)
@@ -108,125 +106,125 @@ class TestPipesMisc(unittest.TestCase):
         with self.assertRaises(AssertionError) as cm:
             misc.check_transfer(self.bad_probe00_folder_3A, self.bad_probe00_folder_3B)
         err = cm.exception
-        self.assertEqual(str(err), 'src_files != dst_files')
+        self.assertEqual(str(err), "src_files != dst_files")
 
     def test_get_new_filename(self):
-        binFname3A = 'ignoreThisPart_g0_t0.imec.ap.bin'
-        binFname3B = 'ignoreThisPart_g0_t0.imec0.ap.bin'
-        metaFname3A = 'ignoreThisPart_g0_t0.imec.ap.meta'
-        metaFname3B = 'ignoreThisPart_g0_t0.imec0.ap.meta'
-        probe1_3B_Meta = 'ignoreThisPart_g0_t0.imec1.ap.meta'
-        different_gt = 'ignoreThisPart_g1_t2.imec0.ap.meta'
+        binFname3A = "ignoreThisPart_g0_t0.imec.ap.bin"
+        binFname3B = "ignoreThisPart_g0_t0.imec0.ap.bin"
+        metaFname3A = "ignoreThisPart_g0_t0.imec.ap.meta"
+        metaFname3B = "ignoreThisPart_g0_t0.imec0.ap.meta"
+        probe1_3B_Meta = "ignoreThisPart_g0_t0.imec1.ap.meta"
+        different_gt = "ignoreThisPart_g1_t2.imec0.ap.meta"
 
         newfname = misc.get_new_filename(binFname3A)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g0_t0.imec.ap.bin')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g0_t0.imec.ap.bin")
         newfname = misc.get_new_filename(binFname3B)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g0_t0.imec0.ap.bin')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g0_t0.imec0.ap.bin")
         newfname = misc.get_new_filename(metaFname3A)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g0_t0.imec.ap.meta')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g0_t0.imec.ap.meta")
         newfname = misc.get_new_filename(metaFname3B)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g0_t0.imec0.ap.meta')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g0_t0.imec0.ap.meta")
         newfname = misc.get_new_filename(probe1_3B_Meta)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g0_t0.imec1.ap.meta')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g0_t0.imec1.ap.meta")
         newfname = misc.get_new_filename(different_gt)
-        self.assertTrue(newfname == '_spikeglx_ephysData_g1_t2.imec0.ap.meta')
+        self.assertTrue(newfname == "_spikeglx_ephysData_g1_t2.imec0.ap.meta")
 
     def _test_rename_ephys_files(self):
         # Test 3A
         misc.rename_ephys_files(self.local_session_path_3A)
-        ap_files = list(self.local_session_path_3A.rglob('*.ap.*'))
-        lf_files = list(self.local_session_path_3A.rglob('*.lf.*'))
+        ap_files = list(self.local_session_path_3A.rglob("*.ap.*"))
+        lf_files = list(self.local_session_path_3A.rglob("*.lf.*"))
         self.assertTrue(len(ap_files) >= 1)
         self.assertTrue(len(lf_files) >= 1)
         for f in ap_files:
             print(f.parent.name, f.name)
-            self.assertTrue('_spikeglx_ephysData_g' in str(f))
-            self.assertTrue('_t' in str(f))
-            self.assertTrue('.imec.ap' in str(f))
-            self.assertTrue(('.bin' in str(f) or '.meta' in str(f)))
-            self.assertTrue(('probe00' in str(f) or 'probe01' in str(f)))
+            self.assertTrue("_spikeglx_ephysData_g" in str(f))
+            self.assertTrue("_t" in str(f))
+            self.assertTrue(".imec.ap" in str(f))
+            self.assertTrue((".bin" in str(f) or ".meta" in str(f)))
+            self.assertTrue(("probe00" in str(f) or "probe01" in str(f)))
         for f in lf_files:
             print(f.parent.name, f.name)
-            self.assertTrue('_spikeglx_ephysData_g' in str(f))
-            self.assertTrue('_t' in str(f))
-            self.assertTrue('.imec.lf' in str(f))
-            self.assertTrue(('.bin' in str(f) or '.meta' in str(f)))  # Test 3B
-            self.assertTrue(('probe00' in str(f) or 'probe01' in str(f)))
+            self.assertTrue("_spikeglx_ephysData_g" in str(f))
+            self.assertTrue("_t" in str(f))
+            self.assertTrue(".imec.lf" in str(f))
+            self.assertTrue((".bin" in str(f) or ".meta" in str(f)))  # Test 3B
+            self.assertTrue(("probe00" in str(f) or "probe01" in str(f)))
         # Test 3B
         misc.rename_ephys_files(self.local_session_path_3B)
-        ap_files = list(self.local_session_path_3B.rglob('*.ap.*'))
-        lf_files = list(self.local_session_path_3B.rglob('*.lf.*'))
-        nidq_files = list(self.local_session_path_3B.rglob('*.nidq.*'))
+        ap_files = list(self.local_session_path_3B.rglob("*.ap.*"))
+        lf_files = list(self.local_session_path_3B.rglob("*.lf.*"))
+        nidq_files = list(self.local_session_path_3B.rglob("*.nidq.*"))
         for f in ap_files:
             print(f.name)
-            self.assertTrue('_spikeglx_ephysData_g' in str(f))
-            self.assertTrue('_t' in str(f))
-            self.assertTrue(('.imec0.ap' in str(f) or 'imec1.ap' in str(f)))
-            self.assertTrue(('.bin' in str(f) or '.meta' in str(f)))
+            self.assertTrue("_spikeglx_ephysData_g" in str(f))
+            self.assertTrue("_t" in str(f))
+            self.assertTrue((".imec0.ap" in str(f) or "imec1.ap" in str(f)))
+            self.assertTrue((".bin" in str(f) or ".meta" in str(f)))
         for f in lf_files:
             print(f.name)
-            self.assertTrue('_spikeglx_ephysData_g' in str(f))
-            self.assertTrue('_t' in str(f))
-            self.assertTrue(('.imec0.lf' in str(f) or 'imec1.lf' in str(f)))
-            self.assertTrue(('.bin' in str(f) or '.meta' in str(f)))  # Test 3B
+            self.assertTrue("_spikeglx_ephysData_g" in str(f))
+            self.assertTrue("_t" in str(f))
+            self.assertTrue((".imec0.lf" in str(f) or "imec1.lf" in str(f)))
+            self.assertTrue((".bin" in str(f) or ".meta" in str(f)))  # Test 3B
         for f in nidq_files:
             print(f.name)
-            self.assertTrue('_spikeglx_ephysData_g' in str(f))
-            self.assertTrue('_t' in str(f))
-            self.assertTrue('.nidq' in str(f))
-            self.assertTrue(('.bin' in str(f) or '.meta' in str(f)))
+            self.assertTrue("_spikeglx_ephysData_g" in str(f))
+            self.assertTrue("_t" in str(f))
+            self.assertTrue(".nidq" in str(f))
+            self.assertTrue((".bin" in str(f) or ".meta" in str(f)))
 
     def test_rename_and_move(self):
         self._test_rename_ephys_files()
         # Test for 3A
         misc.move_ephys_files(self.local_session_path_3A)
-        probe00_files = list(self.probe00_path_3A.rglob('*'))
+        probe00_files = list(self.probe00_path_3A.rglob("*"))
         probe00_file_names = [x.name for x in probe00_files]
-        probe01_files = list(self.probe01_path_3A.rglob('*'))
+        probe01_files = list(self.probe01_path_3A.rglob("*"))
         probe01_file_names = [x.name for x in probe01_files]
 
         self.assertTrue(
-            '_spikeglx_ephysData_g0_t0.imec.ap.bin' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.ap.meta' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.lf.bin' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.lf.meta' in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            '_spikeglx_ephysData_g0_t0.imec.ap.bin' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.ap.meta' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.lf.bin' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec.lf.meta' in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe01_file_names
         )
         # Test for 3B
         misc.move_ephys_files(self.local_session_path_3B)
-        probe00_files = list(self.probe00_path_3B.rglob('*'))
+        probe00_files = list(self.probe00_path_3B.rglob("*"))
         probe00_file_names = [x.name for x in probe00_files]
-        probe01_files = list(self.probe01_path_3B.rglob('*'))
+        probe01_files = list(self.probe01_path_3B.rglob("*"))
         probe01_file_names = [x.name for x in probe01_files]
-        nidq_files = list(self.raw_ephys_data_path_3B.glob('*.nidq.*'))
+        nidq_files = list(self.raw_ephys_data_path_3B.glob("*.nidq.*"))
         nidq_file_names = [x.name for x in nidq_files]
         self.assertTrue(
-            '_spikeglx_ephysData_g0_t0.imec0.ap.bin' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec0.ap.meta' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec0.lf.bin' in probe00_file_names and
-            '_spikeglx_ephysData_g0_t0.imec0.lf.meta' in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec0.ap.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.ap.meta" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.lf.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            '_spikeglx_ephysData_g0_t0.imec1.ap.bin' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec1.ap.meta' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec1.lf.bin' in probe01_file_names and
-            '_spikeglx_ephysData_g0_t0.imec1.lf.meta' in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec1.ap.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.ap.meta" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.lf.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.lf.meta" in probe01_file_names
         )
         self.assertTrue(
-            '_spikeglx_ephysData_g0_t0.nidq.bin' in nidq_file_names and
-            '_spikeglx_ephysData_g0_t0.nidq.meta' in nidq_file_names
+            "_spikeglx_ephysData_g0_t0.nidq.bin" in nidq_file_names
+            and "_spikeglx_ephysData_g0_t0.nidq.meta" in nidq_file_names
         )
 
     def test_create_ephys_transfer_done_flag(self):
         # Create ephys flag file for completed transfer
         misc.create_ephys_transfer_done_flag(self.local_session_path_3A)
         # Check it was created
-        ephys = Path(self.local_session_path_3A).joinpath('ephys_data_transferred.flag')
+        ephys = Path(self.local_session_path_3A).joinpath("ephys_data_transferred.flag")
         self.assertTrue(ephys.exists())
         # Remove it
         ephys.unlink()
@@ -235,15 +233,15 @@ class TestPipesMisc(unittest.TestCase):
         # Create video flag file for completed transfer
         misc.create_video_transfer_done_flag(self.local_session_path_3A)
         # Check it was created
-        video = Path(self.local_session_path_3A).joinpath('video_data_transferred.flag')
+        video = Path(self.local_session_path_3A).joinpath("video_data_transferred.flag")
         self.assertTrue(video.exists())
         # Remove it
         video.unlink()
 
     def test_check_create_raw_session_flag(self):
-        raw_session = Path(self.local_session_path_3A).joinpath('raw_session.flag')
-        ephys = Path(self.local_session_path_3A).joinpath('ephys_data_transferred.flag')
-        video = Path(self.local_session_path_3A).joinpath('video_data_transferred.flag')
+        raw_session = Path(self.local_session_path_3A).joinpath("raw_session.flag")
+        ephys = Path(self.local_session_path_3A).joinpath("ephys_data_transferred.flag")
+        video = Path(self.local_session_path_3A).joinpath("video_data_transferred.flag")
         # Check not created
         misc.check_create_raw_session_flag(self.local_session_path_3A)
         self.assertFalse(raw_session.exists())
@@ -271,12 +269,12 @@ class TestPipesMisc(unittest.TestCase):
         raw_session.unlink()
 
     def test_create_ephys_flags(self):
-        extract = self.local_session_path_3A.joinpath('extract_ephys.flag')
-        qc = self.local_session_path_3A.joinpath('raw_ephys_qc.flag')
-        spike_sorting0 = self.local_session_path_3A / 'raw_ephys_data' / 'probe00'
-        spike_sorting1 = self.local_session_path_3A / 'raw_ephys_data' / 'probe01'
-        spike_sorting0 = spike_sorting0.joinpath('spike_sorting.flag')
-        spike_sorting1 = spike_sorting1.joinpath('spike_sorting.flag')
+        extract = self.local_session_path_3A.joinpath("extract_ephys.flag")
+        qc = self.local_session_path_3A.joinpath("raw_ephys_qc.flag")
+        spike_sorting0 = self.local_session_path_3A / "raw_ephys_data" / "probe00"
+        spike_sorting1 = self.local_session_path_3A / "raw_ephys_data" / "probe01"
+        spike_sorting0 = spike_sorting0.joinpath("spike_sorting.flag")
+        spike_sorting1 = spike_sorting1.joinpath("spike_sorting.flag")
         misc.create_ephys_flags(self.local_session_path_3A)
         self.assertTrue(extract.exists())
         self.assertTrue(qc.exists())
@@ -302,47 +300,86 @@ class TestPipesMisc(unittest.TestCase):
     def test_create_alyx_probe_insertions(self):
         # Connect to test DB
         one = ONE(
-            username='test_user',
-            password='TapetesBloc18',
-            base_url='https://test.alyx.internationalbrainlab.org'
+            username="test_user",
+            password="TapetesBloc18",
+            base_url="https://test.alyx.internationalbrainlab.org",
         )
         # Use existing session on test database
-        eid = 'b1c968ad-4874-468d-b2e4-5ffa9b9964e9'
+        eid = "b1c968ad-4874-468d-b2e4-5ffa9b9964e9"
         # Force probe insertion 3A
-        misc.create_alyx_probe_insertions(
-            eid,
-            one=one,
-            model='3A',
-            labels=['probe00', 'probe01'])
+        misc.create_alyx_probe_insertions(eid, one=one, model="3A", labels=["probe00", "probe01"])
         # Verify it's been inserted
-        alyx_insertion = one.alyx.rest('insertions', 'list',
-                                       session=eid)
-        self.assertTrue(alyx_insertion[0]['model'] == '3A')
-        self.assertTrue(alyx_insertion[0]['name'] in ['probe00', 'probe01'])
-        self.assertTrue(alyx_insertion[1]['model'] == '3A')
-        self.assertTrue(alyx_insertion[1]['name'] in ['probe00', 'probe01'])
+        alyx_insertion = one.alyx.rest("insertions", "list", session=eid)
+        self.assertTrue(alyx_insertion[0]["model"] == "3A")
+        self.assertTrue(alyx_insertion[0]["name"] in ["probe00", "probe01"])
+        self.assertTrue(alyx_insertion[1]["model"] == "3A")
+        self.assertTrue(alyx_insertion[1]["name"] in ["probe00", "probe01"])
         # Cleanup DB
-        one.alyx.rest('insertions', 'delete', id=alyx_insertion[0]['id'])
-        one.alyx.rest('insertions', 'delete', id=alyx_insertion[1]['id'])
+        one.alyx.rest("insertions", "delete", id=alyx_insertion[0]["id"])
+        one.alyx.rest("insertions", "delete", id=alyx_insertion[1]["id"])
         # Force probe insertion 3B
-        misc.create_alyx_probe_insertions(
-            eid,
-            one=one,
-            model='3B2',
-            labels=['probe00', 'probe01'])
+        misc.create_alyx_probe_insertions(eid, one=one, model="3B2", labels=["probe00", "probe01"])
         # Verify it's been inserted
-        alyx_insertion = one.alyx.rest('insertions', 'list',
-                                       session=eid)
-        self.assertTrue(alyx_insertion[0]['model'] == '3B2')
-        self.assertTrue(alyx_insertion[0]['name'] in ['probe00', 'probe01'])
-        self.assertTrue(alyx_insertion[1]['model'] == '3B2')
-        self.assertTrue(alyx_insertion[1]['name'] in ['probe00', 'probe01'])
+        alyx_insertion = one.alyx.rest("insertions", "list", session=eid)
+        self.assertTrue(alyx_insertion[0]["model"] == "3B2")
+        self.assertTrue(alyx_insertion[0]["name"] in ["probe00", "probe01"])
+        self.assertTrue(alyx_insertion[1]["model"] == "3B2")
+        self.assertTrue(alyx_insertion[1]["name"] in ["probe00", "probe01"])
         # Cleanup DB
-        one.alyx.rest('insertions', 'delete', id=alyx_insertion[0]['id'])
-        one.alyx.rest('insertions', 'delete', id=alyx_insertion[1]['id'])
+        one.alyx.rest("insertions", "delete", id=alyx_insertion[0]["id"])
+        one.alyx.rest("insertions", "delete", id=alyx_insertion[1]["id"])
 
     def tearDown(self):
         shutil.rmtree(self.root_test_folder, ignore_errors=True)
+
+
+class TestScanFixPassiveFiles(unittest.TestCase):
+    """"""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        # Session 001 and 002 are 2 sessions with ephys and passive badly transferred
+        (
+            self.session_path,
+            self.passive_session_path,
+        ) = fu.create_fake_ephys_recording_bad_passive_transfer_sessions(
+            self.tmp_dir.name, lab="fakelab", mouse="fakemouse", date="1900-01-01", num="001"
+        )
+        # Create another complete ephys session same mouse and date
+        self.other_good_session = fu.create_fake_complete_ephys_session(
+            self.tmp_dir.name, lab="fakelab", mouse="fakemouse", date="1900-01-01", increment=True
+        )
+
+    def test_scan_fix(self):
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name)
+        self.assertTrue(len(from_to_pairs) == 1)
+        self.assertTrue(sum(moved_ok) == 1)
+        # Second run Nothing to do
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name)
+        self.assertTrue(len(from_to_pairs) == 0)
+        self.assertTrue(sum(moved_ok) == 0)
+
+    def test_find_pairs(self):
+        from_to_pairs = fix.find_pairs(self.tmp_dir.name)
+        self.assertTrue("fakelab/Subjects/fakemouse/1900-01-01/002" in from_to_pairs[0][0])
+        self.assertTrue("fakelab/Subjects/fakemouse/1900-01-01/001" in from_to_pairs[0][1])
+
+    def test_move_rename_pairs(self):
+        # Test all outputs of find function
+        from_to_pairs = []
+        moved_ok = fix.move_rename_pairs(from_to_pairs)
+        self.assertTrue(not moved_ok)
+        # Bad paths
+        from_to_pairs = [('bla', 'ble')]
+        moved_ok = fix.move_rename_pairs(from_to_pairs)
+        self.assertTrue(sum(moved_ok) == 0)
+        # Same as execute
+        from_to_pairs = fix.find_pairs(self.tmp_dir.name)
+        moved_ok = fix.move_rename_pairs(from_to_pairs)
+        self.assertTrue(sum(moved_ok) == 1)
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -184,16 +184,16 @@ class TestPipesMisc(unittest.TestCase):
         probe01_file_names = [x.name for x in probe01_files]
 
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe01_file_names
         )
         # Test for 3B
         misc.move_ephys_files(self.local_session_path_3B)
@@ -204,20 +204,20 @@ class TestPipesMisc(unittest.TestCase):
         nidq_files = list(self.raw_ephys_data_path_3B.glob("*.nidq.*"))
         nidq_file_names = [x.name for x in nidq_files]
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec0.ap.bin" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec0.ap.meta" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec0.lf.bin" in probe00_file_names
-            and "_spikeglx_ephysData_g0_t0.imec0.lf.meta" in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec0.ap.bin" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec0.ap.meta" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec0.lf.bin" in probe00_file_names and
+            "_spikeglx_ephysData_g0_t0.imec0.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec1.ap.bin" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec1.ap.meta" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec1.lf.bin" in probe01_file_names
-            and "_spikeglx_ephysData_g0_t0.imec1.lf.meta" in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec1.ap.bin" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec1.ap.meta" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec1.lf.bin" in probe01_file_names and
+            "_spikeglx_ephysData_g0_t0.imec1.lf.meta" in probe01_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.nidq.bin" in nidq_file_names
-            and "_spikeglx_ephysData_g0_t0.nidq.meta" in nidq_file_names
+            "_spikeglx_ephysData_g0_t0.nidq.bin" in nidq_file_names and
+            "_spikeglx_ephysData_g0_t0.nidq.meta" in nidq_file_names
         )
 
     def test_create_ephys_transfer_done_flag(self):

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -357,11 +357,17 @@ class TestScanFixPassiveFiles(unittest.TestCase):
         )
 
     def test_scan_fix(self):
-        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name)
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name, dry=True)
+        self.assertTrue(len(from_to_pairs) == 1)
+        self.assertTrue(sum(moved_ok) == 0)
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name, dry=False)
         self.assertTrue(len(from_to_pairs) == 1)
         self.assertTrue(sum(moved_ok) == 1)
         # Second run Nothing to do
-        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name)
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name, dry=True)
+        self.assertTrue(len(from_to_pairs) == 0)
+        self.assertTrue(sum(moved_ok) == 0)
+        from_to_pairs, moved_ok = fix.execute(self.tmp_dir.name, dry=False)
         self.assertTrue(len(from_to_pairs) == 0)
         self.assertTrue(sum(moved_ok) == 0)
 

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -307,7 +307,13 @@ class TestPipesMisc(unittest.TestCase):
         # Use existing session on test database
         eid = "b1c968ad-4874-468d-b2e4-5ffa9b9964e9"
         # Force probe insertion 3A
-        misc.create_alyx_probe_insertions(eid, one=one, model="3A", labels=["probe00", "probe01"])
+        misc.create_alyx_probe_insertions(
+            eid,
+            one=one,
+            model='3A',
+            labels=['probe00', 'probe01'],
+            force=True
+        )
         # Verify it's been inserted
         alyx_insertion = one.alyx.rest("insertions", "list", session=eid)
         self.assertTrue(alyx_insertion[0]["model"] == "3A")

--- a/tests/ibllib/test_pipes.py
+++ b/tests/ibllib/test_pipes.py
@@ -184,16 +184,16 @@ class TestPipesMisc(unittest.TestCase):
         probe01_file_names = [x.name for x in probe01_files]
 
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec.ap.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.ap.meta" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec.lf.meta" in probe01_file_names
         )
         # Test for 3B
         misc.move_ephys_files(self.local_session_path_3B)
@@ -204,20 +204,20 @@ class TestPipesMisc(unittest.TestCase):
         nidq_files = list(self.raw_ephys_data_path_3B.glob("*.nidq.*"))
         nidq_file_names = [x.name for x in nidq_files]
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec0.ap.bin" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec0.ap.meta" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec0.lf.bin" in probe00_file_names and
-            "_spikeglx_ephysData_g0_t0.imec0.lf.meta" in probe00_file_names
+            "_spikeglx_ephysData_g0_t0.imec0.ap.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.ap.meta" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.lf.bin" in probe00_file_names
+            and "_spikeglx_ephysData_g0_t0.imec0.lf.meta" in probe00_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.imec1.ap.bin" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec1.ap.meta" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec1.lf.bin" in probe01_file_names and
-            "_spikeglx_ephysData_g0_t0.imec1.lf.meta" in probe01_file_names
+            "_spikeglx_ephysData_g0_t0.imec1.ap.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.ap.meta" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.lf.bin" in probe01_file_names
+            and "_spikeglx_ephysData_g0_t0.imec1.lf.meta" in probe01_file_names
         )
         self.assertTrue(
-            "_spikeglx_ephysData_g0_t0.nidq.bin" in nidq_file_names and
-            "_spikeglx_ephysData_g0_t0.nidq.meta" in nidq_file_names
+            "_spikeglx_ephysData_g0_t0.nidq.bin" in nidq_file_names
+            and "_spikeglx_ephysData_g0_t0.nidq.meta" in nidq_file_names
         )
 
     def test_create_ephys_transfer_done_flag(self):
@@ -308,11 +308,7 @@ class TestPipesMisc(unittest.TestCase):
         eid = "b1c968ad-4874-468d-b2e4-5ffa9b9964e9"
         # Force probe insertion 3A
         misc.create_alyx_probe_insertions(
-            eid,
-            one=one,
-            model='3A',
-            labels=['probe00', 'probe01'],
-            force=True
+            eid, one=one, model="3A", labels=["probe00", "probe01"], force=True
         )
         # Verify it's been inserted
         alyx_insertion = one.alyx.rest("insertions", "list", session=eid)
@@ -382,7 +378,7 @@ class TestScanFixPassiveFiles(unittest.TestCase):
         moved_ok = fix.move_rename_pairs(from_to_pairs)
         self.assertTrue(not moved_ok)
         # Bad paths
-        from_to_pairs = [('bla', 'ble')]
+        from_to_pairs = [("bla", "ble")]
         moved_ok = fix.move_rename_pairs(from_to_pairs)
         self.assertTrue(sum(moved_ok) == 0)
         # Same as execute


### PR DESCRIPTION
Added server script logic to find, move, and rename badly transferred passiveCW sessions to their corresponding ephys sessions.
Will make a PR with the CLI and sh file to be added to the cron jobs in iblscripts...

Implemented fake methods for creating the file footprint of properly transferred ephys session and badly transferred ones. This way the tests for this script can be unittested directly in ibllib. 
These methods live in tests/fixtures/utils.py and might be useful for others.


