### PR TITLE
IblError now inherits Exception instead of BaseException

### DIFF
--- a/ibllib/exceptions.py
+++ b/ibllib/exceptions.py
@@ -1,4 +1,4 @@
-class IblError(BaseException):
+class IblError(Exception):
     explanation = ''
 
     def __init__(self, *args):


### PR DESCRIPTION
Inheriting BaseException instead of Exception in a custom error leads to undesirable behavior, especially in the context of `try/except` statements. `try/except` can't catch BaseException-derived errors (At least in 3.8, haven't tried in older versions of py) and leads to a lot of head-scratching. Unless there's a good reason not to, we should follow the Python guideline on this:

https://docs.python.org/3.8/library/exceptions.html#BaseException

Which recommends that you don't use BaseException but rather Exception for custom errors.