### PR TITLE
spikeglx_version_fix

### DIFF
--- a/ibllib/ephys/spikes.py
+++ b/ibllib/ephys/spikes.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import logging
 import json
 import shutil
+import tarfile
 
 import numpy as np
 
@@ -153,3 +154,55 @@ def ks2_to_alf(ks_path, bin_path, out_path, bin_file=None, ampfactor=1, label=No
     m = ephysqc.phy_model_from_ks2_path(ks2_path=ks_path, bin_path=bin_path, bin_file=bin_file)
     ac = phylib.io.alf.EphysAlfCreator(m)
     ac.convert(out_path, label=label, force=force, ampfactor=ampfactor)
+
+
+def ks2_to_tar(ks_path, out_path):
+    """
+    Compress output from kilosort 2 into tar file in order to register to flatiron and move to
+    alf/probexx path. Output file to register
+
+    :param ks_path: path to kilosort output
+    :param out_path: path to keep the
+    :return
+    path to tar ks output
+
+    To extract files from the tar file can use this code
+    Example:
+        save_path = Path('folder you want to extract to')
+        with tarfile.open('_kilosort_output.tar', 'r') as tar_dir:
+            tar_dir.extractall(path=save_path)
+
+    """
+    ks2_output = ['amplitudes.npy',
+                  'channel_map.npy',
+                  'channel_positions.npy',
+                  'cluster_Amplitude.tsv',
+                  'cluster_ContamPct.tsv',
+                  'cluster_group.tsv',
+                  'cluster_KSLabel.tsv',
+                  'params.py',
+                  'pc_feature_ind.npy',
+                  'pc_features.npy',
+                  'similar_templates.npy',
+                  'spike_clusters.npy',
+                  'spike_sorting_k2.txt',
+                  'spike_templates.npy',
+                  'spike_times.npy',
+                  'template_feature_ind.npy',
+                  'template_features.npy',
+                  'templates.npy',
+                  'templates_ind.npy',
+                  'whitening_mat.npy',
+                  'whitening_mat_inv.npy']
+
+    out_file = Path(out_path).joinpath('_kilosort_output.tar')
+    if out_file.exists():
+        _logger.info(f"Already converted ks2 to tar: for {ks_path}, skipping.")
+        return out_file
+
+    with tarfile.open(out_file, 'x') as tar_dir:
+        for file in Path(ks_path).iterdir():
+            if file.name in ks2_output:
+                tar_dir.add(file, file.name)
+
+    return out_file

--- a/ibllib/ephys/sync_probes.py
+++ b/ibllib/ephys/sync_probes.py
@@ -123,7 +123,7 @@ def version3B(ses_path, display=True, type=None, tol=2.5):
     :return: None
     """
     DEFAULT_TYPE = 'smooth'
-    ephys_files = spikeglx.glob_ephys_files(ses_path, ext='.meta', bin_exists=False)
+    ephys_files = spikeglx.glob_ephys_files(ses_path, ext='meta', bin_exists=False)
     for ef in ephys_files:
         ef['sync'] = alf.io.load_object(ef.path, 'sync', namespace='spikeglx', short_keys=True)
         ef['sync_map'] = get_ibl_sync_map(ef, '3B')

--- a/ibllib/ephys/sync_probes.py
+++ b/ibllib/ephys/sync_probes.py
@@ -123,7 +123,7 @@ def version3B(ses_path, display=True, type=None, tol=2.5):
     :return: None
     """
     DEFAULT_TYPE = 'smooth'
-    ephys_files = spikeglx.glob_ephys_files(ses_path, bin_exists=False)
+    ephys_files = spikeglx.glob_ephys_files(ses_path, ext='.meta', bin_exists=False)
     for ef in ephys_files:
         ef['sync'] = alf.io.load_object(ef.path, 'sync', namespace='spikeglx', short_keys=True)
         ef['sync_map'] = get_ibl_sync_map(ef, '3B')

--- a/ibllib/ephys/sync_probes.py
+++ b/ibllib/ephys/sync_probes.py
@@ -56,7 +56,7 @@ def version3A(ses_path, display=True, type='smooth', tol=2.1):
     :param type: linear, exact or smooth
     :return: bool True on a a successful sync
     """
-    ephys_files = spikeglx.glob_ephys_files(ses_path, bin_exists=False)
+    ephys_files = spikeglx.glob_ephys_files(ses_path, ext='meta', bin_exists=False)
     nprobes = len(ephys_files)
     if nprobes == 1:
         timestamps = np.array([[0., 0.], [1., 1.]])

--- a/ibllib/io/spikeglx.py
+++ b/ibllib/io/spikeglx.py
@@ -431,7 +431,7 @@ def split_sync(sync_tr):
 
 
 def get_neuropixel_version_from_folder(session_path):
-    ephys_files = glob_ephys_files(session_path, ext='.meta')
+    ephys_files = glob_ephys_files(session_path, ext='meta')
     return get_neuropixel_version_from_files(ephys_files)
 
 

--- a/ibllib/io/spikeglx.py
+++ b/ibllib/io/spikeglx.py
@@ -431,7 +431,7 @@ def split_sync(sync_tr):
 
 
 def get_neuropixel_version_from_folder(session_path):
-    ephys_files = glob_ephys_files(session_path)
+    ephys_files = glob_ephys_files(session_path, ext='.meta')
     return get_neuropixel_version_from_files(ephys_files)
 
 

--- a/ibllib/pipes/ephys_preprocessing.py
+++ b/ibllib/pipes/ephys_preprocessing.py
@@ -205,7 +205,8 @@ class SpikeSorting_KS2_Matlab(tasks.Task):
                 out, _ = spikes.sync_spike_sorting(ap_file=ap_file, out_path=probe_out_path)
                 out_files.extend(out)
                 # convert ks2_output into tar file and also register
-                out = spikes.ks2_to_tar(ks2_dir, probe_out_path)
+                tar_dir = self.session_path.joinpath('spike_sorters', 'ks2_matlab', label)
+                out = spikes.ks2_to_tar(ks2_dir, tar_dir)
                 out_files.extend(out)
             except BaseException:
                 _logger.error(traceback.format_exc())

--- a/ibllib/pipes/ephys_preprocessing.py
+++ b/ibllib/pipes/ephys_preprocessing.py
@@ -204,6 +204,9 @@ class SpikeSorting_KS2_Matlab(tasks.Task):
                 )
                 out, _ = spikes.sync_spike_sorting(ap_file=ap_file, out_path=probe_out_path)
                 out_files.extend(out)
+                # convert ks2_output into tar file and also register
+                out = spikes.ks2_to_tar(ks2_dir, probe_out_path)
+                out_files.extend(out)
             except BaseException:
                 _logger.error(traceback.format_exc())
                 self.status = -1

--- a/ibllib/pipes/local_server.py
+++ b/ibllib/pipes/local_server.py
@@ -26,31 +26,33 @@ def _get_lab(one):
         return [la['name'] for la in lab]
 
 
+def _run_command(cmd):
+    process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    info, error = process.communicate()
+    if process.returncode != 0:
+        return None
+    else:
+        return info.decode('utf-8').strip()
+
+
+def _get_volume_usage(vol, label=''):
+    cmd = f'df {vol}'
+    res = _run_command(cmd)
+    # size_list = ['/dev/sdc1', '1921802500', '1427128132', '494657984', '75%', '/datadisk']
+    size_list = re.split(' +', res.split('\n')[-1])
+    fac = 1024 ** 2
+    d = {'total': int(size_list[1]) / fac,
+         'used': int(size_list[2]) / fac,
+         'available': int(size_list[3]) / fac,
+         'volume': size_list[5]}
+    return {f"{label}_{k}": d[k] for k in d}
+
+
 def report_health(one):
     """
     Get a few indicators and label the json field of the corresponding lab with them
     """
-    def _run_command(cmd):
-        process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        info, error = process.communicate()
-        if process.returncode != 0:
-            return None
-        else:
-            return info.decode('utf-8').strip()
-
-    def _get_volume_usage(vol, label=''):
-        cmd = f'df {vol}'
-        res = _run_command(cmd)
-        # size_list = ['/dev/sdc1', '1921802500', '1427128132', '494657984', '75%', '/datadisk']
-        size_list = re.split(' +', res.split('\n')[-1])
-        fac = 1024 ** 2
-        d = {'total': int(size_list[1]) / fac,
-             'used': int(size_list[2]) / fac,
-             'available': int(size_list[3]) / fac,
-             'volume': size_list[5]}
-        return {f"{label}_{k}": d[k] for k in d}
-
     status = {'python_version': sys.version,
               'ibllib_version': pkg_resources.get_distribution("ibllib").version,
               'phylib_version': pkg_resources.get_distribution("phylib").version,


### PR DESCRIPTION
When the .cbin ephys files no longer exist on local servers, cannot apply the sync to extracted alf files because spikeglx.glob_ephys_files returns empty (also causes wrong version 3A to be detected). Change so that it looks for the .meta files instead.