### PR TITLE
Fix breaking of onelib.params.setup() 

### DIFF
--- a/oneibl/params.py
+++ b/oneibl/params.py
@@ -75,11 +75,6 @@ def setup():
              '(leave empty to keep current): '
     par["HTTP_DATA_SERVER_PWD"] = getpass(prompt) or cpar
 
-    cpar = _get_current_par("FTP_DATA_SERVER_PWD", par_current)
-    prompt = "Enter the FlatIron FTP password for " + par["FTP_DATA_SERVER_LOGIN"] +\
-             '(leave empty to keep current): '
-    par["FTP_DATA_SERVER_PWD"] = getpass(prompt) or cpar
-
     # default to home dir if empty dir somehow made it here
     if len(par['CACHE_DIR']) == 0:
         par['CACHE_DIR'] = str(PurePath(Path.home(), "Downloads", "FlatIron"))

--- a/oneibl/tests/test_params.py
+++ b/oneibl/tests/test_params.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import oneibl.params as params
 from ibllib.io import params as iopar
+from getpass import getpass
 
 
 class TestONEParams(unittest.TestCase):
@@ -22,6 +23,13 @@ class TestONEParams(unittest.TestCase):
                 params._get_current_par(
                     k, self.par_current) == self.par_default.as_dict()[k])
 
+    def test_setup(self):
+        # overwrite getpass,input and print method to silence prompts and prints
+        params.input = lambda prompt: 'mock_input'
+        params.getpass = lambda prompt: 'mock_pwd'
+        params.print = lambda text: 'mock_print'
+        params.setup()
+
     def test_setup_silent(self):
         self.assertIsNone(iopar.read(params._PAR_ID_STR))
         params.setup_silent()
@@ -39,6 +47,10 @@ class TestONEParams(unittest.TestCase):
         if self.bk_params.exists():
             shutil.copy(self.bk_params, self.existing_params)
             self.bk_params.unlink()
+        #Reassign original functions
+        params.getpass = getpass
+        params.input = input
+        params.print = print
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
HI, a small fix for a problem I encountered setting up ONE. I am not sure about the protocol for contributing yet, so just opening the PR to get feedback. In principle I assume I should write a test to reproduce the problem, which is fixed by this PR?
