### PR TITLE
Atlas lateralization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# IBL Python Libraries
-[![Build Status on master](https://travis-ci.org/int-brain-lab/ibllib.svg?branch=master)](https://travis-ci.org/int-brain-lab/ibllib) 
+# IBL Python Libraries 
 [![Coverage badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fibllib.hooks.internationalbrainlab.org%2Fcoverage%2Fibllib%2Fmaster)](https://ibllib.hooks.internationalbrainlab.org/coverage/master) 
-[![Tests status badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fibllib.hooks.internationalbrainlab.org%2Ftests%2Fibllib%2Fmaster)](https://ibllib.hooks.internationalbrainlab.org/logs/records/master) 
+[![Tests status badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fibllib.hooks.internationalbrainlab.org%2Ftests%2Fibllib%2Fmaster)](https://ibllib.hooks.internationalbrainlab.org/logs/records/master)
+[![Tests status badge](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fibllib.hooks.internationalbrainlab.org%2Ftests%2Fibllib%2Fmaster)](https://ibllib.hooks.internationalbrainlab.org/logs/records/develop)
 
 ## Description
 Library used to implement the International Brain Laboratory data pipeline. Currently in active development.

--- a/ibllib/atlas/atlas.py
+++ b/ibllib/atlas/atlas.py
@@ -711,8 +711,14 @@ class AllenAtlas(BrainAtlas):
         """
         par = params.read('one_params')
         FLAT_IRON_ATLAS_REL_PATH = Path('histology', 'ATLAS', 'Needles', 'Allen')
-        MD5_LUT = 'a529ada7db10777bff31cf9916074663'  # if updating lut needs to update here
+        MD5_LUT = '148f297cc5aa5a3767f4aa61701f7e0b'  # if updating lut needs to update here
         regions = BrainRegions()
+        xyz2dims = np.array([1, 0, 2])  # this is the c-contiguous ordering
+        dims2xyz = np.array([1, 0, 2])
+        # we use Bregma as the origin
+        self.res_um = res_um
+        ibregma = (ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / self.res_um)
+        dxyz = self.res_um * 1e-6 * np.array([1, -1, -1]) * scaling
         if mock:
             image, label = [np.zeros((528, 456, 320), dtype=np.int16) for _ in range(2)]
             label[:, :, 100:105] = 1327  # lookup index for retina, id 304325711 (no id 1327)
@@ -733,18 +739,18 @@ class AllenAtlas(BrainAtlas):
             if not file_label_remap.exists():
                 label = self._read_volume(file_label)
                 _logger.info("computing brain atlas annotations lookup table")
+                # lateralize atlas: for this the regions of the left hemisphere have primary
+                # keys opposite to to the normal ones
+                lateral = np.zeros(label.shape[xyz2dims[0]])
+                lateral[int(np.floor(ibregma[0]))] = 1
+                lateral = np.sign(np.cumsum(lateral)[np.newaxis, :, np.newaxis] - 0.5)
+                label = label * lateral
                 _, im = ismember(label, regions.id)
                 label = np.reshape(im.astype(np.uint16), label.shape)
                 np.savez_compressed(file_label_remap, label)
             # loads the files
             label = self._read_volume(file_label_remap)
             image = self._read_volume(file_image)
-        xyz2dims = np.array([1, 0, 2])  # this is the c-contiguous ordering
-        dims2xyz = np.array([1, 0, 2])
-        dxyz = res_um * 1e-6 * np.array([1, -1, -1]) * scaling
-        # we use Bregma as the origin
-        ibregma = (ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / res_um)
-        self.res_um = res_um
         super().__init__(image, label, dxyz, regions, ibregma,
                          dims2xyz=dims2xyz, xyz2dims=xyz2dims)
 

--- a/ibllib/atlas/regions.py
+++ b/ibllib/atlas/regions.py
@@ -25,9 +25,18 @@ class _BrainRegions:
 class BrainRegions(_BrainRegions):
     """
     ibllib.atlas.regions.BrainRegions(brainmap='Allen')
+    The Allen atlas ids are kept intact but lateralized as follows: labels are duplicated
+     and ids multiplied by -1, with the understanding that left hemisphere regions have negative
+     ids.
     """
     def __init__(self):
         df_regions = pd.read_csv(FILE_REGIONS)
+        # lateralize
+        df_regions_left = df_regions.iloc[np.array(df_regions.id > 0), :].copy()
+        df_regions_left['id'] = - df_regions_left['id']
+        df_regions_left['parent_structure_id'] = - df_regions_left['parent_structure_id']
+        df_regions_left['name'] = df_regions_left['name'].apply(lambda x: x + ' (left)')
+        df_regions = pd.concat((df_regions, df_regions_left), axis=0)
         # converts colors to RGB uint8 array
         c = np.uint32(df_regions.color_hex_triplet.map(
             lambda x: int(x, 16) if isinstance(x, str) else 256 ** 3 - 1))
@@ -42,8 +51,10 @@ class BrainRegions(_BrainRegions):
                          parent=df_regions.parent_structure_id.to_numpy())
         # mappings are indices not ids: they range from 0 to n regions -1
         self.mappings = {
-            'Allen': np.arange(self.id.size),
-            'Beryl': self._mapping_from_regions_list(BERYL),
+            'Allen': self._mapping_from_regions_list(np.unique(np.abs(self.id)), lateralize=False),
+            'Allen-lr': np.arange(self.id.size),
+            'Beryl': self._mapping_from_regions_list(BERYL, lateralize=False),
+            'Beryl-lr': self._mapping_from_regions_list(BERYL, lateralize=True),
         }
 
     def get(self, ids) -> Bunch:
@@ -103,7 +114,7 @@ class BrainRegions(_BrainRegions):
         leaves = np.setxor1d(self.id, self.parent)
         return self.get(np.int64(leaves[~np.isnan(leaves)]))
 
-    def _mapping_from_regions_list(self, new_map):
+    def _mapping_from_regions_list(self, new_map, lateralize=False):
         """
         From a vector of regions id, creates a mapping such as
         newids = self.mapping
@@ -111,9 +122,13 @@ class BrainRegions(_BrainRegions):
         """
         I_ROOT = 1
         I_VOID = 0
-        assert np.all(np.sort(new_map) == np.unique(new_map)), "Mapping ids should be unique"
-        _, iid, inm = np.intersect1d(self.id, new_map, return_indices=True)
-        assert (iid.size == new_map.size), "All mapping ids should be represented in the Allen ids"
+        # to lateralize we make sure all regions are represented in + and -
+        new_map = np.unique(np.r_[-new_map, new_map])
+        assert np.all(np.isin(new_map, self.id)), \
+            "All mapping ids should be represented in the Allen ids"
+        # with the lateralization, self.id may have duplicate values so ismember is necessary
+        iid, inm = ismember(self.id, new_map)
+        iid = np.where(iid)[0]
         mapind = np.zeros_like(self.id) + I_ROOT  # non assigned regions are root
         mapind[iid] = iid  # regions present in the list have the same index
         # Starting by the higher up levels in the hierarchy, assign all descendants to the mapping
@@ -122,6 +137,10 @@ class BrainRegions(_BrainRegions):
             _, idesc, _ = np.intersect1d(self.id, descendants, return_indices=True)
             mapind[idesc] = iid[i]
         mapind[0] = I_VOID  # void stays void
+        # to delateralize the regions, assign the positive index to all mapind elements
+        if lateralize is False:
+            _, iregion = ismember(np.abs(self.id), self.id)
+            mapind = mapind[iregion]
         return mapind
 
 


### PR DESCRIPTION
Changes to the raw volume to reflect lateral regions.
Regions object has twice as many regions, with negative regions corresponding to left hemishphere.

The default lookup behaviour stays hemisphere agnostic as the default mapping stays 'Allen'. For lateralized mappings use 'Allen_lr'.