### PR TITLE
Enh/task

### DIFF
--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -31,7 +31,7 @@ class Task(abc.ABC):
     time_out_secs = None
     version = version.ibllib()
 
-    def __init__(self, session_path, parents=None, taskid=None, one=None):
+    def __init__(self, session_path, parents=None, taskid=None, one=None, machine=None):
         self.taskid = taskid
         self.one = one
         self.session_path = session_path
@@ -40,6 +40,7 @@ class Task(abc.ABC):
             self.parents = parents
         else:
             self.parents = []
+        self.machine = machine
 
     @property
     def name(self):
@@ -66,6 +67,8 @@ class Task(abc.ABC):
         ch.setFormatter(logging.Formatter(str_format))
         _logger.addHandler(ch)
         _logger.info(f"Starting job {self.__class__}")
+        if self.machine:
+            _logger.info(f"Running on machine {self.machine}")
         # run
         start_time = time.time()
         self.status = 0

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -59,10 +59,10 @@ class Task(abc.ABC):
         # if taskid of one properties are not available, local run only without alyx
         use_alyx = self.one is not None and self.taskid is not None
         if use_alyx:
-            self.one.alyx.rest('tasks', 'partial_update',
-                               id=self.taskid, data={'status': 'Started'})
-            pre_log = self.one.alyx.rest('tasks', 'list', id=self.taskid)[0]['log']
-            self.log = pre_log + '\n\n' if pre_log else ''
+            tdict = self.one.alyx.rest('tasks', 'partial_update', id=self.taskid,
+                                       data={'status': 'Started'})
+            self.log = ('' if not tdict['log'] else tdict['log'] +
+                        '\n\n=============================RERUN=============================\n')
         # setup
         self.setUp()
         # Setup the console handler with a StringIO object

--- a/ibllib/tests/test_tasks.py
+++ b/ibllib/tests/test_tasks.py
@@ -177,9 +177,14 @@ class TestPipelineAlyx(unittest.TestCase):
         # check that logs were correctly amended
         check_logs = [t['log'].count(desired_logs) == desired_logs_rerun[t['name']] if t['log']
                       else t['log'] == desired_logs_rerun[t['name']] for t in task_deck]
+        check_rerun = ['===RERUN===' in t['log'] if desired_logs_rerun[t['name']] == 2
+                       else True for t in task_deck]
         self.assertTrue(all(check_logs))
+        self.assertTrue(all(check_rerun))
 
         # Rerun with clobber and check that logs are overwritten
         task_deck, dsets = pipeline.rerun_failed(machine='testmachine', clobber=True)
         check_logs = [t['log'].count(desired_logs) == 1 if t['log'] else True for t in task_deck]
+        check_rerun = ['===RERUN===' not in t['log'] if t['log'] else True for t in task_deck]
         self.assertTrue(all(check_logs))
+        self.assertTrue(all(check_rerun))

--- a/ibllib/tests/test_tasks.py
+++ b/ibllib/tests/test_tasks.py
@@ -34,6 +34,14 @@ desired_datasets = ['spikes.times.npy', 'spikes.amps.npy', 'spikes.clusters.npy'
 desired_versions = {'spikes.times.npy': 'custom_job00',
                     'spikes.amps.npy': version.ibllib(),
                     'spikes.clusters.npy': version.ibllib()}
+desired_logs = 'Running on machine: testmachine'
+desired_logs_rerun = {
+    'Task00': 1,
+    'Task01_void': 2,
+    'Task02_error': 2,
+    'Task10': 1,
+    'Task11': None
+}
 
 
 #  job to output a single file (pathlib.Path)
@@ -124,7 +132,7 @@ class TestPipelineAlyx(unittest.TestCase):
 
     def test_pipeline_alyx(self):
         eid = self.eid
-        pipeline = SomePipeline(self.session_path, one=one, machine='testmachine')
+        pipeline = SomePipeline(self.session_path, one=one)
 
         # prepare by deleting all jobs/tasks related
         tasks = one.alyx.rest('tasks', 'list', session=eid)
@@ -141,14 +149,13 @@ class TestPipelineAlyx(unittest.TestCase):
         self.assertTrue(len(tasks) == NTASKS)
 
         # run them and make sure their statuses got updated appropriately
-        task_deck, datasets = pipeline.run()
+        task_deck, datasets = pipeline.run(machine='testmachine')
         check_statuses = [desired_statuses[t['name']] == t['status'] for t in task_deck]
         # [(t['name'], t['status'], desired_statuses[t['name']]) for t in task_deck]
         self.assertTrue(all(check_statuses))
         self.assertTrue(set([d['name'] for d in datasets]) == set(desired_datasets))
-        # check that machine gets registered
-        check_logs = ['Running on machine testmachine' in t['log'] for t in task_deck
-                      if t['log'] is not None]
+        # check logs
+        check_logs = [desired_logs in t['log'] if t['log'] else True for t in task_deck]
         self.assertTrue(all(check_logs))
 
         # also checks that the datasets have been labeled with the proper version
@@ -163,6 +170,16 @@ class TestPipelineAlyx(unittest.TestCase):
         self.assertTrue(all(check_statuses))
 
         # test the rerun option
-        task_deck, dsets = pipeline.rerun_failed()
+        task_deck, dsets = pipeline.rerun_failed(machine='testmachine')
         check_statuses = [desired_statuses[t['name']] == t['status'] for t in task_deck]
         self.assertTrue(all(check_statuses))
+
+        # check that logs were correctly amended
+        check_logs = [t['log'].count(desired_logs) == desired_logs_rerun[t['name']] if t['log']
+                      else t['log'] == desired_logs_rerun[t['name']] for t in task_deck]
+        self.assertTrue(all(check_logs))
+
+        # Rerun with clobber and check that logs are overwritten
+        task_deck, dsets = pipeline.rerun_failed(machine='testmachine', clobber=True)
+        check_logs = [t['log'].count(desired_logs) == 1 if t['log'] else True for t in task_deck]
+        self.assertTrue(all(check_logs))

--- a/ibllib/tests/test_tasks.py
+++ b/ibllib/tests/test_tasks.py
@@ -124,7 +124,7 @@ class TestPipelineAlyx(unittest.TestCase):
 
     def test_pipeline_alyx(self):
         eid = self.eid
-        pipeline = SomePipeline(self.session_path, one=one)
+        pipeline = SomePipeline(self.session_path, one=one, machine='testmachine')
 
         # prepare by deleting all jobs/tasks related
         tasks = one.alyx.rest('tasks', 'list', session=eid)
@@ -146,6 +146,10 @@ class TestPipelineAlyx(unittest.TestCase):
         # [(t['name'], t['status'], desired_statuses[t['name']]) for t in task_deck]
         self.assertTrue(all(check_statuses))
         self.assertTrue(set([d['name'] for d in datasets]) == set(desired_datasets))
+        # check that machine gets registered
+        check_logs = ['Running on machine testmachine' in t['log'] for t in task_deck
+                      if t['log'] is not None]
+        self.assertTrue(all(check_logs))
 
         # also checks that the datasets have been labeled with the proper version
         dsets = one.alyx.rest('datasets', 'list', session=eid)


### PR DESCRIPTION
Adding two new arguments to `Task.__init__()` , passed on to `Task.run()` , as well as the `Pipeline.run()` and `Pipeline.run_alyx_task()` function. 
1. `machine`: string to tag the machine a task or pipeline is run on. Defaults to None, if not None, will be logged.
2. `clobber`: boolean to indicate whether or not existing logs on alyx should be overwritten. This defaults to False, meaning that the **default behavior will be changed** by this PR. 

Happy for any comments!