### PR TITLE
Return GPIO as nx4 bool array

### DIFF
--- a/brainbox/tests/test_core.py
+++ b/brainbox/tests/test_core.py
@@ -41,6 +41,8 @@ class TestBunch(unittest.TestCase):
             abunch.save(npz_filec, compress=True)
             another_bunch = core.Bunch.load(npz_filec)
             [self.assertTrue(np.all(abunch[k]) == np.all(another_bunch[k])) for k in abunch]
+            with self.assertRaises(FileNotFoundError):
+                core.Bunch.load(Path(td) / 'fake.npz')
 
 
 if __name__ == "__main__":

--- a/ibllib/io/extractors/camera.py
+++ b/ibllib/io/extractors/camera.py
@@ -89,7 +89,7 @@ class CameraTimestampsFPGA(BaseExtractor):
         :return: a numpy array of camera timestamps
         """
         fpga_times = extract_camera_sync(sync=sync, chmap=chmap)
-        count, gpio = raw.load_embedded_frame_data(self.session_path, self.label)
+        count, (*_, gpio) = raw.load_embedded_frame_data(self.session_path, self.label)
 
         if gpio is not None and gpio['indices'].size > 1:
             _logger.info('Aligning to audio TTLs')
@@ -164,7 +164,7 @@ class CameraTimestampsBpod(BaseBpodTrialsExtractor):
         :return: a numpy array of camera timestamps
         """
         raw_ts = self._times_from_bpod()
-        count, gpio = raw.load_embedded_frame_data(self.session_path, 'left')
+        count, (*_, gpio) = raw.load_embedded_frame_data(self.session_path, 'left')
         if video_path is None:
             filename = '_iblrig_leftCamera.raw.mp4'
             video_path = self.session_path.joinpath('raw_video_data', filename)

--- a/ibllib/io/raw_data_loaders.py
+++ b/ibllib/io/raw_data_loaders.py
@@ -180,12 +180,18 @@ def load_camera_gpio(session_path, label: str, as_dicts=False):
     """
     Load the GPIO for a given session.  If the file doesn't exist, or is empty, a None value is
     returned.
+
+    The raw binary file contains uint32 values (saved as doubles) where the first 4 bits
+    represent the state of each of the 4 GPIO pins. The array is expanded to an n x 4 array by
+    shifting each bit to the end and checking whether it is 0 (low state) or 1 (high state).
+
     :param session_path: Absolute path of session folder
     :param label: The specific video to load, one of ('left', 'right', 'body')
-    :param as_dicts: If False the raw data are returned without preprocessing, otherwise GPIO is
-    returned as dictionary of front indices and polarities
+    :param as_dicts: If False the raw data are returned boolean array with shape (n_frames, n_pins)
+     otherwise GPIO is returned as a list of dictionaries with keys ('indices', 'polarities').
     :return: An nx4 boolean array where columns represent state of GPIO pins 1-4.
-    If as_dict is True, a tuple of dicts is returned with 'indices' and 'polarities' keys, or Nones
+     If as_dicts is True, a list of dicts is returned with keys ('indices', 'polarities'),
+     or None if the dictionary is empty.
     """
     if session_path is None:
         return

--- a/ibllib/tests/qc/test_camera_qc.py
+++ b/ibllib/tests/qc/test_camera_qc.py
@@ -87,8 +87,8 @@ class TestCameraQC(unittest.TestCase):
         self.assertEqual('NOT_SET', self.qc.check_pin_state())
         # Add some dummy data
         self.qc.data.timestamps = np.array([round(1 / FPS, 4)] * 5).cumsum()
-        self.qc.data.pin_state = np.zeros_like(self.qc.data.timestamps, dtype=int)
-        self.qc.data.pin_state[1:-1] = 10000
+        self.qc.data.pin_state = np.zeros((self.qc.data.timestamps.size, 4), dtype=bool)
+        self.qc.data.pin_state[1:-1, -1] = True  # Pulse on 4th pin
         self.qc.data['video'] = {'fps': FPS, 'length': len(self.qc.data.timestamps)}
         self.qc.data.audio = self.qc.data.timestamps[[0, -1]] - 10e-3
 
@@ -100,7 +100,7 @@ class TestCameraQC(unittest.TestCase):
         np.testing.assert_array_equal(b, self.qc.data.audio)
 
         # Fudge some numbers
-        self.qc.data.pin_state[2] = 11e3
+        self.qc.data['video']['length'] = self.qc.data.pin_state.shape[0] - 3
         self.assertEqual('WARNING', self.qc.check_pin_state()[0])
         self.qc.data['video']['length'] = 10
         outcome, *dTTL = self.qc.check_pin_state()

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -233,8 +233,8 @@ class TestsRawDataLoaders(unittest.TestCase):
         self.assertEqual(count[0], int(16696704))
 
         # Test empty / None
-        self.assertIsNone(raw.load_camera_gpio(None, 'body'))
-        self.assertIsNone(raw.load_camera_gpio(session, 'right'))
+        self.assertIsNone(raw.load_camera_frame_count(None, 'body'))
+        self.assertIsNone(raw.load_camera_frame_count(session, 'right'))
 
     def test_load_embedded_frame_data(self):
         session = Path(__file__).parent.joinpath('extractors', 'data', 'session_ephys')

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -240,7 +240,7 @@ class TestsRawDataLoaders(unittest.TestCase):
         session = Path(__file__).parent.joinpath('extractors', 'data', 'session_ephys')
         count, gpio = raw.load_embedded_frame_data(session, 'body')
         self.assertEqual(count[0], 0)
-        self.assertIsInstance(gpio[0], dict)
+        self.assertIsInstance(gpio[-1], dict)
         count, gpio = raw.load_embedded_frame_data(session, 'body', raw=True)
         self.assertNotEqual(count[0], 0)
         self.assertIsInstance(gpio, np.ndarray)

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -185,7 +185,7 @@ class TestsRawDataLoaders(unittest.TestCase):
         :return:
         """
         session = Path(__file__).parent.joinpath('extractors', 'data', 'session_ephys')
-        gpio = raw.load_camera_gpio(session, 'body', as_dict=True)
+        gpio = raw.load_camera_gpio(session, 'body', as_dicts=True)
         self.assertEqual(len(gpio), 4)  # One dict per pin
         *gpio_, gpio_4 = gpio  # Check last dict; pin 4 should have one pulse
         self.assertTrue(all(k in ('indices', 'polarities') for k in gpio_4.keys()))
@@ -193,14 +193,14 @@ class TestsRawDataLoaders(unittest.TestCase):
         np.testing.assert_array_equal(gpio_4['polarities'], np.array([1, -1]))
 
         # Test raw flag
-        gpio = raw.load_camera_gpio(session, 'body', as_dict=False)
+        gpio = raw.load_camera_gpio(session, 'body', as_dicts=False)
         self.assertEqual(gpio.dtype, bool)
         self.assertEqual(gpio.shape, (510, 4))
 
         # Test empty / None
         self.assertIsNone(raw.load_camera_gpio(None, 'body'))
         self.assertIsNone(raw.load_camera_gpio(session, 'right'))
-        [self.assertIsNone(x) for x in raw.load_camera_gpio(session, 'right', as_dict=True)]
+        [self.assertIsNone(x) for x in raw.load_camera_gpio(session, 'right', as_dicts=True)]
 
         # Test noisy GPIO data
         side = 'right'
@@ -210,12 +210,12 @@ class TestsRawDataLoaders(unittest.TestCase):
             filename = session_path / 'raw_video_data' / f'_iblrig_{side}Camera.GPIO.bin'
             np.full(1000, 1.87904819e+09, dtype=np.float64).tofile(filename)
             with self.assertRaises(AssertionError):
-                raw.load_camera_gpio(session_path, side, as_dict=True)
+                raw.load_camera_gpio(session_path, side, as_dicts=True)
 
             # Test dead pin array
             np.zeros(3000, dtype=np.float64).tofile(filename)
             with self.assertLogs('ibllib', level='ERROR'):
-                gpio = raw.load_camera_gpio(session_path, side, as_dict=True)
+                gpio = raw.load_camera_gpio(session_path, side, as_dicts=True)
                 [self.assertIsNone(x) for x in gpio]
 
     def test_load_camera_frame_count(self):

--- a/ibllib/tests/test_misc.py
+++ b/ibllib/tests/test_misc.py
@@ -1,8 +1,10 @@
 import unittest
 import logging
 import time
+import types
 
 from ibllib.misc import (version, print_progress)
+from ibllib.misc import flatten as flt
 
 
 class TestPrintProgress(unittest.TestCase):
@@ -62,6 +64,16 @@ class TestLoggingSystem(unittest.TestCase):
         logger.warning('ROOT This is a warning message')
         logger.info('ROOT This is an info message')
         logger.debug('ROOT This is a debug message')
+
+
+class TestFlatten(unittest.TestCase):
+
+    def test_flatten(self):
+        x = (1, 2, 3, [1, 2], 'string', 0.1, {1: None}, [[1, 2, 3], {1: 1}, 1])
+        self.assertEqual(flt.iflatten(x), flt.flatten(x))
+        self.assertEqual(flt.flatten(x)[:5], [1, 2, 3, 1, 2])
+        self.assertEqual(list(flt.gflatten(x)), list(flt.flatten(x, generator=True)))
+        self.assertIsInstance(flt.flatten(x, generator=True), types.GeneratorType)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Following Nicco's revelation that the pin state values encode the 4 pin states I've changed the loader to return a boolean array with the shape (n_frames, n_pins), where n_pins is 4.  

I don't consider bit shifting as 'extraction' any more than typecasting.  To read the binary file in any other form, simply load it directly (e.g. with a numpy loader).  

The as_dict argument (default=False) now returns a tuple of 4 dicts, one per pin, or a None for the pins that were inactive.