### PR TITLE
Orphaned audio TTLs

### DIFF
--- a/ibllib/io/extractors/camera.py
+++ b/ibllib/io/extractors/camera.py
@@ -578,9 +578,9 @@ def groom_pin_state(gpio, audio, ts, tolerance=2., display=False, take='first', 
                 orphaned_offsets, =  np.where(~to_remove.reshape(-1, 2)[:, 1] & orphaned)
                 for i, v in enumerate(orphaned_offsets):
                     orphaned_offsets[i] -= to_remove.reshape(-1, 2)[:v, 1].sum()
-                # Remove orphaned onsets and offsets
-                onsets_ = np.delete(onsets_, orphaned_onsets)
-                offsets_ = np.delete(offsets_, orphaned_offsets)
+                # Remove orphaned audio onsets and offsets
+                onsets_ = np.delete(onsets_, orphaned_onsets[orphaned_onsets < onsets_.size])
+                offsets_ = np.delete(offsets_, orphaned_offsets[orphaned_offsets < offsets_.size])
                 _logger.debug(f'{orphaned.sum()} orphaned TTLs removed')
                 to_remove.reshape(-1, 2)[orphaned] = True
 

--- a/ibllib/io/extractors/video_motion.py
+++ b/ibllib/io/extractors/video_motion.py
@@ -38,7 +38,7 @@ class MotionAlignment:
     def __init__(self, eid, one=None, log=logging.getLogger('ibllib'), **kwargs):
         self.one = one or ONE()
         self.eid = eid
-        self.session_path = self.one.path_from_eid(eid)
+        self.session_path = kwargs.pop('session_path', self.one.path_from_eid(eid))
         if self.one and not isinstance(self.one, OneOffline):
             self.ref = eid2ref(self.eid, as_dict=False, one=self.one)
         else:

--- a/ibllib/qc/camera.py
+++ b/ibllib/qc/camera.py
@@ -514,7 +514,7 @@ class CameraQC(base.QC):
         if not wheel_present or self.side == 'body':
             return 'NOT_SET'
 
-        aln = MotionAlignment(self.eid, self.one, self.log)
+        aln = MotionAlignment(self.eid, self.one, self.log, session_path=self.session_path)
         aln.data = self.data.copy()
         aln.data['camera_times'] = {self.side: self.data['timestamps']}
         aln.video_paths = {self.side: self.video_path}


### PR DESCRIPTION
Fixed index error when removing orphaned audio TTLs in the grooming function.  I ran this on about 25 of the 34 error'd sessions and they all extracted.  

Also the old way of extracting timestamps is used as a fallback if any of the assertions fail.  Besides this and the GPIO loader issue I haven't seen any other errors that aren't genuine problems with the hardware.  The fallback will make any future failures hard to detect - you'll have to rely on the QC - but it means the video will be registered in most cases.