### PR TITLE
FileNotFound error when loading params w/o defaults

### DIFF
--- a/ibllib/io/params.py
+++ b/ibllib/io/params.py
@@ -46,36 +46,42 @@ def getfile(str_params):
     if sys.platform == 'win32' or sys.platform == 'cygwin':
         pfile = str(PurePath(os.environ['APPDATA'], *parts))
     else:
-        pfile = str(PurePath(Path.home(), *parts))
+        pfile = str(Path.home().joinpath(*parts))
     return pfile
 
 
 def read(str_params, default=None):
     """
-    Reads in and parse Json parameter file into dictionary
+    Reads in and parse Json parameter file into dictionary.  If the parameter file doesn't
+    exist and no defaults are provided, a FileNotFound error is raised, otherwise any extra
+    default parameters will be written into the file.
+
+    Examples:
+        # Load parameters, raise error if file not found
+        par = read('globus/admin')
+
+        # Load with defaults
+        par = read('globus/admin', {'local_endpoint': None, 'remote_endpoint': None})
+
+        # Return empty dict if file not found (i.e. touch new param file)
+        par = read('new_pars', {})
 
     :param str_params: path to text json file
     :param default: default values for missing parameters
     :return: named tuple containing parameters
     """
     pfile = getfile(str_params)
+    par_dict = as_dict(default) or {}
     if Path(pfile).exists():
         with open(pfile) as fil:
-            par_dict = json.loads(fil.read())
-    else:
-        par_dict = as_dict(default)
-    # without default parameters
-    default = as_dict(default)
-    # TODO : behaviour for non existing file
-    # tat = params.read('rijafa', default={'toto': 'titi', 'tata': 1})
-    if not default or default.keys() == par_dict.keys():
-        return from_dict(par_dict)
-    # if default parameters bring in a new parameter
-    new_keys = set(default.keys()).difference(set(par_dict.keys()))
-    for nk in new_keys:
-        par_dict[nk] = default[nk]
-    # write the new parameter file with the extra param
-    write(str_params, par_dict)
+            file_pars = json.loads(fil.read())
+        par_dict.update(file_pars)
+    elif default is None:  # No defaults provided
+        raise FileNotFoundError(f'Parameter file {pfile} not found')
+
+    if not Path(pfile).exists() or par_dict.keys() > file_pars.keys():
+        # write the new parameter file with the extra param
+        write(str_params, par_dict)
     return from_dict(par_dict)
 
 

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -61,20 +61,20 @@ class TestsParams(unittest.TestCase):
                            'E': 'tete2',
                            }
         par2 = params.read('toto', default=default)
-        self.assertEqual(par2, params.from_dict(expected_result))
+        self.assertCountEqual(par2.as_dict(), expected_result)
         # on the next path the parameter has been added to the param file
         par2 = params.read('toto', default=default)
-        self.assertEqual(par2, params.from_dict(expected_result))
+        self.assertCountEqual(par2.as_dict(), expected_result)
         # check that it doesn't break if a named tuple is given instead of a dict
         par3 = params.read('toto', default=par2)
         self.assertEqual(par2, par3)
-        # check that a non-existing parfile returns None
+        # check that a non-existing parfile raises error
         pstring = str(uuid.uuid4())
-        par = params.read(pstring)
-        self.assertIsNone(par)
+        with self.assertRaises(FileNotFoundError):
+            params.read(pstring)
         # check that a non-existing parfile with default returns default
         par = params.read(pstring, default=default)
-        self.assertEqual(par, params.from_dict(default))
+        self.assertCountEqual(par, params.from_dict(default))
         # even if this default is a Params named tuple
         par = params.read(pstring, default=par)
         self.assertEqual(par, params.from_dict(default))

--- a/oneibl/params.py
+++ b/oneibl/params.py
@@ -12,7 +12,7 @@ def default():
     par = {"ALYX_LOGIN": "test_user",
            "ALYX_PWD": "TapetesBloc18",
            "ALYX_URL": "https://test.alyx.internationalbrainlab.org",
-           "CACHE_DIR": str(PurePath(Path.home(), "Downloads", "FlatIron")),
+           "CACHE_DIR": str(Path.home() / "Downloads" / "FlatIron"),
            "HTTP_DATA_SERVER": "https://ibl.flatironinstitute.org",
            "HTTP_DATA_SERVER_LOGIN": "iblmember",
            "HTTP_DATA_SERVER_PWD": None,
@@ -28,20 +28,9 @@ def _get_current_par(k, par_current):
 
 
 def setup_silent():
-    par_current = iopar.read(_PAR_ID_STR)
-    par_default = default()
-    if par_current is None:
-        par = par_default
-    else:
-        par = iopar.as_dict(par_default)
-        for k in par.keys():
-            cpar = _get_current_par(k, par_current)
-            par[k] = cpar
-        par = iopar.from_dict(par)
-
+    par = iopar.read(_PAR_ID_STR, default())
     if par.CACHE_DIR:
         Path(par.CACHE_DIR).mkdir(parents=True, exist_ok=True)
-    iopar.write(_PAR_ID_STR, par)
 
 
 def setup_alyx_params():
@@ -55,10 +44,8 @@ def setup_alyx_params():
 
 # first get current and default parameters
 def setup():
-    par_current = iopar.read(_PAR_ID_STR)
     par_default = default()
-    if par_current is None:
-        par_current = par_default
+    par_current = iopar.read(_PAR_ID_STR, par_default)
 
     par = iopar.as_dict(par_default)
     for k in par.keys():
@@ -77,7 +64,7 @@ def setup():
 
     # default to home dir if empty dir somehow made it here
     if len(par['CACHE_DIR']) == 0:
-        par['CACHE_DIR'] = str(PurePath(Path.home(), "Downloads", "FlatIron"))
+        par['CACHE_DIR'] = str(Path.home() / "Downloads" / "FlatIron")
 
     par = iopar.from_dict(par)
 

--- a/oneibl/params.py
+++ b/oneibl/params.py
@@ -1,7 +1,7 @@
 import os
 from ibllib.io import params as iopar
 from getpass import getpass
-from pathlib import Path, PurePath
+from pathlib import Path
 from ibllib.graphic import login
 
 

--- a/oneibl/tests/test_params.py
+++ b/oneibl/tests/test_params.py
@@ -31,7 +31,8 @@ class TestONEParams(unittest.TestCase):
         params.setup()
 
     def test_setup_silent(self):
-        self.assertIsNone(iopar.read(params._PAR_ID_STR))
+        with self.assertRaises(FileNotFoundError):
+            iopar.read(params._PAR_ID_STR)
         params.setup_silent()
         par = iopar.read(params._PAR_ID_STR)
         self.assertIsNotNone(par)

--- a/release_notes.md
+++ b/release_notes.md
@@ -2,6 +2,9 @@
 - Video QC optimization
 - New task types for widefield imaging
 - Add revision and default dataset to register dataset 
+- Fix for camera extraction failure for novel protocols
+- CameraQC wheel alignment check more robust to short videos and large alignment failures
+- Parameters raises FileNotFound error if no defaults are provided
 
 ## Release Notes 1.8
 ### Release Notes 1.8.0 - 2020-03-30


### PR DESCRIPTION
I refactored `ibllib.io.params.read`:

- If no defaults are provided and the file doesn't exist, an error is raised (NB: an empty dict counts as a default here)
- All other behaviour is preserved however the order of the loaded parameters is not guaranteed to be the same

This behaviour is more consistent with functions such as `pop` and `get`.