### PR TITLE
All check outcomes in extended QC map

### DIFF
--- a/ibllib/qc/camera.py
+++ b/ibllib/qc/camera.py
@@ -343,7 +343,7 @@ class CameraQC(base.QC):
             extended = {
                 k: None if v is None or v == 'NOT_SET'
                 else base.CRITERIA[v] < 3 if isinstance(v, str)
-                else v[1:] if len(v) > 2 else v[-1]  # Otherwise store custom value(s)
+                else (base.CRITERIA[v[0]] < 3, *v[1:])  # Convert first value to bool if array
                 for k, v in self.metrics.items()
             }
             self.update_extended_qc(extended)


### PR DESCRIPTION
e.g.
```
{'videoLeft': 'FAIL',
 '_videoLeft_focus': False,
 '_videoLeft_position': True,
 '_videoLeft_framerate': [True, 30.03],
 '_videoLeft_pin_state': [True, 383, 0],
 '_videoLeft_brightness': False,
 '_videoLeft_resolution': True,
 '_videoLeft_timestamps': True,
 '_videoLeft_camera_times': [True, 0],
 '_videoLeft_file_headers': True,
 '_videoLeft_dropped_frames': [True, 4, 0],
 '_videoLeft_wheel_alignment': [True, 0]}
```