### PR TITLE
Fix raw_session.flag creation from training tasks on ephys rig

### DIFF
--- a/ibllib/pipes/misc.py
+++ b/ibllib/pipes/misc.py
@@ -406,7 +406,9 @@ def check_create_raw_session_flag(session_folder: str) -> None:
         return
 
     is_biased = True if "biased" in sett["PYBPOD_PROTOCOL"] else False
-    if video.exists() and is_biased:
+    is_training = True if "training" in sett["PYBPOD_PROTOCOL"] else False
+    is_habituation = True if "habituation" in sett["PYBPOD_PROTOCOL"] else False
+    if video.exists() and (is_biased or is_training or is_habituation):
         flags.write_flag_file(session_path.joinpath("raw_session.flag"))
         video.unlink()
     if video.exists() and ephys.exists():

--- a/ibllib/pipes/transfer_rig_data.py
+++ b/ibllib/pipes/transfer_rig_data.py
@@ -10,6 +10,7 @@ from shutil import ignore_patterns as ig
 
 import ibllib.io.extractors.base
 import ibllib.io.flags as flags
+import ibllib.io.raw_data_loaders as raw
 
 log = logging.getLogger('ibllib')
 log.setLevel(logging.INFO)
@@ -49,6 +50,9 @@ def main(local_folder: str, remote_folder: str, force: bool = False) -> None:
             task_type = ibllib.io.extractors.base.get_session_extractor_type(Path(src))
             if task_type not in ['ephys', 'ephys_sync', 'ephys_mock']:
                 flags.write_flag_file(dst.joinpath('raw_session.flag'))
+                settings = raw.load_settings(dst)
+                if 'ephys' in settings['PYBPOD_BOARD']:  # Any traing task on an ephys rig
+                    dst.joinpath('raw_session.flag').unlink()
             log.info(f"Copied to {remote_folder}: Session {src_flag_file.parent}")
             src_flag_file.unlink()
 

--- a/ibllib/pipes/transfer_rig_data.py
+++ b/ibllib/pipes/transfer_rig_data.py
@@ -57,10 +57,10 @@ def main(local_folder: str, remote_folder: str, force: bool = False) -> None:
             src_flag_file.unlink()
 
         # Cleanup
-        src_audio_file = src / 'raw_behavior_data' / '_iblrig_micData.raw.wav'
         src_video_file = src / 'raw_video_data' / '_iblrig_leftCamera.raw.avi'
-        dst_audio_file = dst / 'raw_behavior_data' / '_iblrig_micData.raw.wav'
         dst_video_file = dst / 'raw_video_data' / '_iblrig_leftCamera.raw.avi'
+        src_audio_file = src / 'raw_behavior_data' / '_iblrig_micData.raw.wav'
+        dst_audio_file = dst / 'raw_behavior_data' / '_iblrig_micData.raw.wav'
 
         if src_audio_file.exists() and \
                 src_audio_file.stat().st_size == dst_audio_file.stat().st_size:

--- a/ibllib/tests/test_pipes.py
+++ b/ibllib/tests/test_pipes.py
@@ -224,6 +224,24 @@ class TestPipesMisc(unittest.TestCase):
         self.assertTrue(raw_session.exists())
         self.assertFalse(video.exists())
         raw_session.unlink()
+        # Check if training session
+        fu.populate_task_settings(
+            fpath, patch={"PYBPOD_PROTOCOL": "some_trainingChoiceWorld_task"}
+        )
+        misc.create_video_transfer_done_flag(self.session_path_3B)
+        misc.check_create_raw_session_flag(self.session_path_3B)
+        self.assertTrue(raw_session.exists())
+        self.assertFalse(video.exists())
+        raw_session.unlink()
+        # Check if habituation session
+        fu.populate_task_settings(
+            fpath, patch={"PYBPOD_PROTOCOL": "some_habituationChoiceWorld_task"}
+        )
+        misc.create_video_transfer_done_flag(self.session_path_3B)
+        misc.check_create_raw_session_flag(self.session_path_3B)
+        self.assertTrue(raw_session.exists())
+        self.assertFalse(video.exists())
+        raw_session.unlink()
 
     def test_create_ephys_flags(self):
         extract = self.session_path_3B.joinpath('extract_ephys.flag')


### PR DESCRIPTION
If habituation or training CW tasks are ran on the ephys rig the transfer would create the raw session flag before the video was transferred and consequently the preprocessing would start before video files were transferred and fail.
This only happened for a couple of mainenlab tasks (Ines) when she started running training tasks (not biased) on the ephys rig