### PR TITLE
add opto extraction for widefieldChoiceWorld

### DIFF
--- a/ibllib/io/extractors/extractor_types.json
+++ b/ibllib/io/extractors/extractor_types.json
@@ -4,7 +4,7 @@
  "ephyskarolinaChoiceWorld": "ephys_biased_opto",
  "trainingChoiceWorldWidefield": "ephys_training",
  "passive_opto": "ephys",
- "widefieldChoiceWorld": "ephys",
+ "widefieldChoiceWorld": "ephys_biased_opto",
  "opto_biasedChoiceWorld": "biased_opto",
  "opto_biased_ChoiceWord": "biased_opto",
  "optoChoiceWorld": "biased_opto",


### PR DESCRIPTION
can I still use the extractor type "ephys_biased_opto" (which stipulates that the biased blocks are not pre-defined) even if I am using the predefined blocks without error? or will the added extraction of block and contrast cause errors with the predefined blocks? If you think this will be a problem, please reject pull request.