### PR TITLE
load_spike_sorting now loads in pykilosort data if it exists

### DIFF
--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -256,7 +256,7 @@ def load_spike_sorting(eid, one=None, probe=None, dataset_types=None, spike_sort
         if (spike_sorter is None) & (f'alf/{label}/pykilosort' in one.list_collections(eid)):
             collection = f'alf/{label}/pykilosort'
         elif spike_sorter is None:
-            collection = f'alf/{label}/'
+            collection = f'alf/{label}'
         else:
             collection = f'alf/{label}/{spike_sorter}'
 

--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -219,6 +219,7 @@ def load_spike_sorting(eid, one=None, probe=None, dataset_types=None, spike_sort
     :return: spikes, clusters (dict of bunch, 1 bunch per probe)
     """
     one = one or ONE()
+    details = one.get_details(eid, full=True)
 
     if isinstance(probe, str):
         labels = [probe]
@@ -252,8 +253,10 @@ def load_spike_sorting(eid, one=None, probe=None, dataset_types=None, spike_sort
 
     for label in labels:
 
-        if spike_sorter is None:
-            collection = f'alf/{label}'
+        if (spike_sorter is None) & (f'alf/{label}/pykilosort' in one.list_collections(eid)):
+            collection = f'alf/{label}/pykilosort'
+        elif spike_sorter is None:
+            collection = f'alf/{label}/'
         else:
             collection = f'alf/{label}/{spike_sorter}'
 


### PR DESCRIPTION
Currently load_spike_sorting crashes if the data is in the pykilosort collection. I added some lines so that it loads in the pykilosort spike data (if it exists).