### PR TITLE
AllenAtlas always returns coordinates in um

### DIFF
--- a/ibllib/atlas/atlas.py
+++ b/ibllib/atlas/atlas.py
@@ -15,6 +15,7 @@ _logger = logging.getLogger('ibllib')
 ALLEN_CCF_LANDMARKS_MLAPDV_UM = {'bregma': np.array([5739., 5400., 332.])}
 """dict: Landmarks in Allen CCF coordinates (MLAPDV / um)."""
 
+
 def cart2sph(x, y, z):
     """
     Converts cartesian to spherical Coordinates

--- a/ibllib/tests/test_atlas.py
+++ b/ibllib/tests/test_atlas.py
@@ -86,7 +86,7 @@ class TestAtlasSlicesConversion(unittest.TestCase):
         self.assertTrue(ba.slice(axis=2, coordinate=.002).shape == (ny, nx))  # horizontal
         # tests out of bound
         with self.assertRaises(IndexError):
-            ba.slice(axis=1, coordinate=123)
+            ba.slice(axis=1, coordinate=123e6)
         self.assertTrue(ba.slice(axis=1, coordinate=21, mode='clip').shape == (nx, nz))
         """
         here we test the different volumes and mappings
@@ -193,7 +193,8 @@ class TestInsertion(unittest.TestCase):
                               [0.002489, -0.004275, -0.004893],
                               [0.002439, -0.004375, -0.005093],
                               [0.002364, -0.0044, -0.005418]])
-        insertion = Insertion.from_track(xyz_track, brain_atlas)
+        # brain_atlas (AllenAtlas) in um; xyz_track in m -> converted to um
+        insertion = Insertion.from_track(xyz_track * 1e6, brain_atlas)
         self.assertTrue(abs(insertion.theta - 10.58704241) < 1e6)
         # Test that the entry and exit intersection are computed properly
         brain_entry = insertion.get_brain_entry(insertion.trajectory, brain_atlas)


### PR DESCRIPTION
Fix for issue https://github.com/int-brain-lab/iblenv/issues/261. 

The problem appears to be that the BrainAtlas class operates in meters, while its subclass, AllenAtlas, operates in micrometers.  Additionally some BrainAtlas methods return values in micrometers (i.e. extent and plot_tilted_slice).  Other classes such as Insertion expect inputs to be micrometers.  I added an assert in Insertion._get_surface_intersection as it assumes the atlas is the Allen one (assumes units in um; uses the subclass property res_um).

Perhaps the output units should be a class property (similar to the scaling factor) and the internal units should be consistent.