### PR TITLE
Fix returning 27 outputs

### DIFF
--- a/ibllib/pipes/ephys_preprocessing.py
+++ b/ibllib/pipes/ephys_preprocessing.py
@@ -976,7 +976,7 @@ class EphysDLC(tasks.Task):
                 expected_outputs_present, expected_outputs = self.assert_expected(self.output_files, silent=True)
                 if overwrite is False and expected_outputs_present is True:
                     actual_outputs.extend(expected_outputs)
-                    continue
+                    return actual_outputs
                 else:
                     file_mp4 = next(self.session_path.joinpath('raw_video_data').glob(f'_iblrig_{cam}Camera.raw*.mp4'))
                     if not file_mp4.exists():

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,3 +1,6 @@
+## To be added to next release
+- Fix in EphysDLC task to not return multiple copies of outputs
+
 ## Release Note 2.9
 
 ### Release Notes 2.9.1 2022-01-24


### PR DESCRIPTION
Small fix to avoid all outputs to be returned three times (when they exist and overwrite is False)