### PR TITLE
CI QC Tests

### DIFF
--- a/ibllib/pipes/ephys_preprocessing.py
+++ b/ibllib/pipes/ephys_preprocessing.py
@@ -442,7 +442,7 @@ class SpikeSorting(tasks.Task):
                             out = get_aligned_channels(ins[0], chns, one=self.one, save_dir=probe_out_path)
                             out_files.extend(out)
 
-            except BaseException:
+            except Exception:
                 _logger.error(traceback.format_exc())
                 self.status = -1
                 continue

--- a/ibllib/pipes/widefield_tasks.py
+++ b/ibllib/pipes/widefield_tasks.py
@@ -17,7 +17,7 @@ from ibllib.pipes import base_tasks
 from ibllib.io.video import get_video_meta
 import labcams.io
 
-_logger = logging.getLogger('ibllib')
+_logger = logging.getLogger(__name__)
 
 
 class WidefieldRegisterRaw(base_tasks.WidefieldTask, base_tasks.RegisterRawDataTask):

--- a/ibllib/qc/task_extractors.py
+++ b/ibllib/qc/task_extractors.py
@@ -89,7 +89,7 @@ class TaskQCExtractor(object):
                             'ephysData.raw.wiring'])
 
         dataset = self.one.type2datasets(eid, dstypes, details=True)
-        files = self.one._download_datasets(dataset)
+        files = self.one._check_filesystem(dataset)
 
         missing = [True] * len(dstypes) if not files else [x is None for x in files]
         if self.session_path is None or all(missing):


### PR DESCRIPTION
Avoid re-download of task QC data by calling check_filesystem instead of download_datasets