### PR TITLE
Switch to previous value interpolation of position

### DIFF
--- a/brainbox/behavior/wheel.py
+++ b/brainbox/behavior/wheel.py
@@ -24,7 +24,7 @@ ENC_RES = 1024 * 4  # Rotary encoder resolution, assumes X4 encoding
 WHEEL_DIAMETER = 3.1 * 2  # Wheel diameter in cm
 
 
-def interpolate_position(re_ts, re_pos, freq=1000, kind='linear', fill_gaps=None):
+def interpolate_position(re_ts, re_pos, freq=1000, kind='previous', fill_gaps=None):
     """
     Return linearly interpolated wheel position.
 


### PR DESCRIPTION
The current implementation of `brainbox.behavior.wheel.interpolate_position` relies on linear interpolation of a given point when resampling the encoder to a fixed frequency. This causes a given point at time `t` to be interpolated using information from both timestep `t - dt_1` and `t + dt_2` for some arbitrary deltas relative to the previous and next sampled points. This is an issue for causality.

More concretely, it results in some pretty crazy colinearities in the GLM, and I really need that fixed so I can finish a run for the BWM. 