### PR TITLE
HOTFIX: floferlab multiple file records

### DIFF
--- a/ibllib/oneibl/registration.py
+++ b/ibllib/oneibl/registration.py
@@ -7,7 +7,9 @@ import itertools
 from pkg_resources import parse_version
 from one.alf.files import get_session_path, folder_parts, get_alf_path
 from one.registration import RegistrationClient, get_dataset_type
-from one.remote.globus import get_local_endpoint_id
+from one.remote.globus import get_local_endpoint_id, get_lab_from_endpoint_id
+from one.webclient import AlyxClient
+from one.converters import ConversionMixin
 import one.alf.exceptions as alferr
 from one.util import datasets2records, ensure_list
 
@@ -462,20 +464,41 @@ def get_local_data_repository(ac):
     return next((da['name'] for da in data_repo), None)
 
 
-def get_lab(ac):
+def get_lab(session_path, alyx=None):
     """
-    Get list of associated labs from Globus client ID.
+    Get lab from a session path using the subject name.
+
+    On local lab servers, the lab name is not in the ALF path and the globus endpoint ID may be
+    associated with multiple labs, so lab name is fetched from the subjects endpoint.
 
     Parameters
     ----------
-    ac : one.webclient.AlyxClient
+    session_path : str, pathlib.Path
+        The session path from which to determine the lab name.
+    alyx : one.webclient.AlyxClient
         An AlyxClient instance for querying data repositories.
 
     Returns
     -------
-    list
-        The lab names associated with the local Globus endpoint ID.
+    str
+        The lab name associated with the session path subject.
+
+    See Also
+    --------
+    one.remote.globus.get_lab_from_endpoint_id
     """
-    globus_id = get_local_endpoint_id()
-    lab = ac.rest('labs', 'list', django=f'repositories__globus_endpoint_id,{globus_id}')
-    return [la['name'] for la in lab]
+    alyx = alyx or AlyxClient()
+    if not (ref := ConversionMixin.path2ref(session_path)):
+        raise ValueError(f'Failed to parse session path: {session_path}')
+
+    labs = [x['lab'] for x in alyx.rest('subjects', 'list', nickname=ref['subject'])]
+    if len(labs) == 0:
+        raise alferr.AlyxSubjectNotFound(ref['subject'])
+    elif len(labs) > 1:  # More than one subject with this nickname
+        # use local endpoint ID to find the correct lab
+        endpoint_labs = get_lab_from_endpoint_id(alyx=alyx)
+        lab = next(x for x in labs if x in endpoint_labs)
+    else:
+        lab, = labs
+
+    return lab

--- a/ibllib/pipes/local_server.py
+++ b/ibllib/pipes/local_server.py
@@ -10,6 +10,8 @@ import traceback
 import importlib
 
 from one.api import ONE
+from one.webclient import AlyxClient
+from one.remote.globus import get_lab_from_endpoint_id
 
 from ibllib.io.extractors.base import get_pipeline, get_task_protocol, get_session_extractor_type
 from ibllib.pipes import tasks, training_preprocessing, ephys_preprocessing
@@ -72,35 +74,49 @@ def report_health(one):
     status.update(_get_volume_usage('/mnt/s0/Data', 'raid'))
     status.update(_get_volume_usage('/', 'system'))
 
-    lab_names = get_lab(one.alyx)
+    lab_names = get_lab_from_endpoint_id(alyx=one.alyx)
     for ln in lab_names:
         one.alyx.json_field_update(endpoint='labs', uuid=ln, field_name='json', data=status)
 
 
 def job_creator(root_path, one=None, dry=False, rerun=False, max_md5_size=None):
     """
-    Server function that will look for creation flags and for each:
-    1) create the sessions on Alyx
-    2) register the corresponding raw data files on Alyx
-    3) create the tasks to be run on Alyx
-    :param root_path: main path containing sessions or session path
-    :param one
-    :param dry
-    :param rerun
-    :param max_md5_size
-    :return:
+    Create new sessions and pipelines.
+
+    Server function that will look for 'raw_session.flag' files and for each:
+     1) create the session on Alyx
+     2) create the tasks to be run on Alyx
+
+    For legacy sessions the raw data are registered separately, instead of within a pipeline task.
+
+    Parameters
+    ----------
+    root_path : str, pathlib.Path
+        Main path containing sessions or a session path.
+    one : one.api.OneAlyx
+        An ONE instance for registering the session(s).
+    dry : bool
+        If true, simply log the session_path(s) found, without registering anything.
+    rerun : bool
+        If true and session pipeline tasks already exist, set them all to waiting.
+    max_md5_size : int
+        (legacy sessions) The maximum file size to calculate the MD5 hash sum for.
+
+    Returns
+    -------
+    list of ibllib.pipes.tasks.Pipeline
+        The pipelines created.
     """
     if not one:
         one = ONE(cache_rest=None)
     rc = IBLRegistrationClient(one=one)
     flag_files = list(Path(root_path).glob('**/raw_session.flag'))
-    all_datasets = []
+    pipes = []
     for flag_file in flag_files:
         session_path = flag_file.parent
         _logger.info(f'creating session for {session_path}')
         if dry:
             continue
-
         try:
             # if the subject doesn't exist in the database, skip
             rc.register_session(session_path, file_list=False)
@@ -112,10 +128,8 @@ def job_creator(root_path, one=None, dry=False, rerun=False, max_md5_size=None):
             else:
                 # Create legacy experiment description file
                 acquisition_description_legacy_session(session_path, save=True)
-                labs = ','.join(get_lab(one.alyx))
-                files, dsets = register_session_raw_data(session_path, one=one, max_md5_size=max_md5_size, labs=labs)
-                if dsets is not None:
-                    all_datasets.extend(dsets)
+                lab = get_lab(session_path, one.alyx)  # Can be set to None to do this Alyx-side if using ONE v1.20.1
+                register_session_raw_data(session_path, one=one, max_md5_size=max_md5_size, labs=lab)
                 pipe = _get_pipeline_class(session_path, one)
                 if pipe is None:
                     task_protocol = get_task_protocol(session_path)
@@ -126,15 +140,16 @@ def job_creator(root_path, one=None, dry=False, rerun=False, max_md5_size=None):
                 rerun__status__in = ['Waiting']
             pipe.create_alyx_tasks(rerun__status__in=rerun__status__in)
             flag_file.unlink()
+            pipes.append(pipe)
         except Exception:
             _logger.error(traceback.format_exc())
             _logger.warning(f'Creating session / registering raw datasets {session_path} errored')
             continue
 
-    return all_datasets
+    return pipes
 
 
-def task_queue(mode='all', lab=None, one=None):
+def task_queue(mode='all', lab=None, alyx=None):
     """
     Query waiting jobs from the specified Lab
     :param mode: Whether to return all waiting tasks, or only small or large (specified in LARGE_TASKS) jobs
@@ -143,18 +158,17 @@ def task_queue(mode='all', lab=None, one=None):
     -------
 
     """
-    if one is None:
-        one = ONE(cache_rest=None)
+    alyx = alyx or AlyxClient(cache_rest=None)
     if lab is None:
-        _logger.debug("Trying to infer lab from globus installation")
-        lab = get_lab(one.alyx)
+        _logger.debug('Trying to infer lab from globus installation')
+        lab = get_lab_from_endpoint_id(alyx=alyx)
     if lab is None:
-        _logger.error("No lab provided or found")
+        _logger.error('No lab provided or found')
         return  # if the lab is none, this will return empty tasks each time
-    data_repo = get_local_data_repository(one)
+    data_repo = get_local_data_repository(alyx)
     # Filter for tasks
-    tasks_all = one.alyx.rest('tasks', 'list', status='Waiting',
-                              django=f'session__lab__name__in,{lab},data_repository__name,{data_repo}', no_cache=True)
+    tasks_all = alyx.rest('tasks', 'list', status='Waiting',
+                          django=f'session__lab__name__in,{lab},data_repository__name,{data_repo}', no_cache=True)
     if mode == 'all':
         waiting_tasks = tasks_all
     else:

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -387,7 +387,11 @@ class Pipeline(abc.ABC):
         if one and one.alyx.cache_mode and one.alyx.default_expiry.seconds > 1:
             _logger.warning('Alyx client REST cache active; this may cause issues with jobs')
         self.eid = eid
-        self.data_repo = get_local_data_repository(self.one.alyx)
+        if self.one and not self.one.offline:
+            self.data_repo = get_local_data_repository(self.one.alyx)
+        else:
+            self.data_repo = None
+
         if session_path:
             self.session_path = session_path
             if not self.eid:

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -19,10 +19,11 @@ import one.params
 from one.api import ONE
 
 _logger = logging.getLogger(__name__)
+TASK_STATUS_SET = {'Waiting', 'Held', 'Started', 'Errored', 'Empty', 'Complete', 'Incomplete', 'Abandoned'}
 
 
 class Task(abc.ABC):
-    log = ""  # place holder to keep the log of the task for registration
+    log = ''  # place holder to keep the log of the task for registration
     cpu = 1   # CPU resource
     gpu = 0   # GPU resources: as of now, either 0 or 1
     io_charge = 5  # integer percentage
@@ -59,7 +60,7 @@ class Task(abc.ABC):
         self.register_kwargs = {}
         if parents:
             self.parents = parents
-            self.level = max([p.level for p in self.parents]) + 1
+            self.level = max(p.level for p in self.parents) + 1
         else:
             self.parents = []
         self.machine = machine
@@ -104,15 +105,15 @@ class Task(abc.ABC):
         ch.setFormatter(logging.Formatter(str_format))
         _logger.parent.addHandler(ch)
         _logger.parent.setLevel(logging.INFO)
-        _logger.info(f"Starting job {self.__class__}")
+        _logger.info(f'Starting job {self.__class__}')
         if self.machine:
-            _logger.info(f"Running on machine: {self.machine}")
-        _logger.info(f"running ibllib version {ibllib.__version__}")
+            _logger.info(f'Running on machine: {self.machine}')
+        _logger.info(f'running ibllib version {ibllib.__version__}')
         # setup
         start_time = time.time()
         try:
             setup = self.setUp(**kwargs)
-            _logger.info(f"Setup value is: {setup}")
+            _logger.info(f'Setup value is: {setup}')
             self.status = 0
             if not setup:
                 # case where outputs are present but don't have input files locally to rerun task
@@ -123,17 +124,17 @@ class Task(abc.ABC):
                 if self.gpu >= 1:
                     if not self._creates_lock():
                         self.status = -2
-                        _logger.info(f"Job {self.__class__} exited as a lock was found")
+                        _logger.info(f'Job {self.__class__} exited as a lock was found')
                         new_log = log_capture_string.getvalue()
                         self.log = new_log if self.clobber else self.log + new_log
                         _logger.removeHandler(ch)
                         ch.close()
                         return self.status
                 self.outputs = self._run(**kwargs)
-                _logger.info(f"Job {self.__class__} complete")
+                _logger.info(f'Job {self.__class__} complete')
         except Exception:
             _logger.error(traceback.format_exc())
-            _logger.info(f"Job {self.__class__} errored")
+            _logger.info(f'Job {self.__class__} errored')
             self.status = -1
 
         self.time_elapsed_secs = time.time() - start_time
@@ -145,8 +146,8 @@ class Task(abc.ABC):
         else:
             nout = 1
 
-        _logger.info(f"N outputs: {nout}")
-        _logger.info(f"--- {self.time_elapsed_secs} seconds run-time ---")
+        _logger.info(f'N outputs: {nout}')
+        _logger.info(f'--- {self.time_elapsed_secs} seconds run-time ---')
         # after the run, capture the log output, amend to any existing logs if not overwrite
         new_log = log_capture_string.getvalue()
         self.log = new_log if self.clobber else self.log + new_log
@@ -273,7 +274,7 @@ class Task(abc.ABC):
 
         if not everything_is_fine:
             for out in self.outputs:
-                _logger.error(f"{out}")
+                _logger.error(f'{out}')
             if raise_error:
                 raise FileNotFoundError("Missing outputs after task completion")
 
@@ -289,7 +290,7 @@ class Task(abc.ABC):
         everything_is_fine, files = self.assert_expected(self.input_files)
 
         if not everything_is_fine and raise_error:
-            raise FileNotFoundError("Missing inputs to run task")
+            raise FileNotFoundError('Missing inputs to run task')
 
         return everything_is_fine, files
 
@@ -301,7 +302,7 @@ class Task(abc.ABC):
             if len(actual_files) == 0 and expected_file[2]:
                 everything_is_fine = False
                 if not silent:
-                    _logger.error(f"Signature file expected {expected_file} not found")
+                    _logger.error(f'Signature file expected {expected_file} not found')
             else:
                 if len(actual_files) != 0:
                     files.append(actual_files[0])
@@ -332,7 +333,7 @@ class Task(abc.ABC):
         return dhandler
 
     @staticmethod
-    def make_lock_file(taskname="", time_out_secs=7200):
+    def make_lock_file(taskname='', time_out_secs=7200):
         """Creates a GPU lock file with a timeout of"""
         d = {'start': time.time(), 'name': taskname, 'time_out_secs': time_out_secs}
         with open(Task._lock_file_path(), 'w+') as fid:
@@ -404,9 +405,9 @@ class Pipeline(abc.ABC):
         :return: string containing the full module plus class name
         """
         if obj.__module__ == 'abc':
-            exec_name = f"{obj.__class__.__base__.__module__}.{obj.__class__.__base__.__name__}"
+            exec_name = f'{obj.__class__.__base__.__module__}.{obj.__class__.__base__.__name__}'
         else:
-            exec_name = f"{obj.__module__}.{obj.name}"
+            exec_name = f'{obj.__module__}.{obj.name}'
         return exec_name
 
     def make_graph(self, out_dir=None, show=True):
@@ -438,19 +439,29 @@ class Pipeline(abc.ABC):
         """
         Instantiate the pipeline and create the tasks in Alyx, then create the jobs for the session
         If the jobs already exist, they are left untouched. The re-run parameter will re-init the
-        job by emptying the log and set the status to Waiting
-        :param rerun__status__in: by default no re-run. To re-run tasks if they already exist,
-        specify a list of statuses string that will be re-run, those are the possible choices:
-        ['Waiting', 'Started', 'Errored', 'Empty', 'Complete']
-        to always patch, the string '__all__' can also be provided
-        :return: list of alyx tasks dictionaries (existing and or created)
+        job by emptying the log and set the status to Waiting.
+
+        Parameters
+        ----------
+        rerun__status__in : list, str
+            To re-run tasks if they already exist, specify one or more statuses strings to will be
+            re-run, or '__all__' to re-run all tasks.
+        tasks_list : list
+            The list of tasks to create on Alyx. If None, uses self.tasks.
+
+        Returns
+        -------
+        list
+            List of Alyx task dictionaries (existing and/or created).
         """
-        rerun__status__in = rerun__status__in or []
-        if rerun__status__in == '__all__':
-            rerun__status__in = ['Waiting', 'Started', 'Errored', 'Empty', 'Complete']
+        rerun__status__in = ([rerun__status__in]
+                             if isinstance(rerun__status__in, str)
+                             else rerun__status__in or [])
+        if '__all__' in rerun__status__in:
+            rerun__status__in = [x for x in TASK_STATUS_SET if x != 'Abandoned']
         assert self.eid
         if self.one is None:
-            _logger.warning("No ONE instance found for Alyx connection, set the one property")
+            _logger.warning('No ONE instance found for Alyx connection, set the one property')
             return
         tasks_alyx_pre = self.one.alyx.rest('tasks', 'list', session=self.eid, graph=self.name, no_cache=True)
         tasks_alyx = []
@@ -460,7 +471,7 @@ class Pipeline(abc.ABC):
             task_items = tasks_list
             # need to add in the session eid and the parents
         else:
-            task_items = [t for _, t in self.tasks.items()]
+            task_items = self.tasks.values()
 
         for t in task_items:
             # get the parents' alyx ids to reference in the database
@@ -469,8 +480,8 @@ class Pipeline(abc.ABC):
                 executable = t.executable
                 arguments = t.arguments
                 t['time_out_secs'] = t['time_out_sec']
-                if len(t.parents):
-                    pnames = [p for p in t.parents]
+                if len(t.parents) > 0:
+                    pnames = t.parents
             else:
                 executable = self._get_exec_name(t)
                 arguments = t.kwargs
@@ -491,12 +502,11 @@ class Pipeline(abc.ABC):
             if self.data_repo:
                 task_dict.update({'data_repository': self.data_repo})
             # if the task already exists, patch it otherwise, create it
-            talyx = next(filter(lambda x: x["name"] == t.name, tasks_alyx_pre), [])
+            talyx = next(filter(lambda x: x['name'] == t.name, tasks_alyx_pre), [])
             if len(talyx) == 0:
                 talyx = self.one.alyx.rest('tasks', 'create', data=task_dict)
-            elif rerun__status__in == '__all__' or talyx['status'] in rerun__status__in:
-                talyx = self.one.alyx.rest(
-                    'tasks', 'partial_update', id=talyx['id'], data=task_dict)
+            elif talyx['status'] in rerun__status__in:
+                talyx = self.one.alyx.rest('tasks', 'partial_update', id=talyx['id'], data=task_dict)
             tasks_alyx.append(talyx)
         return tasks_alyx
 
@@ -527,7 +537,7 @@ class Pipeline(abc.ABC):
 
         return tasks_list
 
-    def run(self, status__in=['Waiting'], machine=None, clobber=True, **kwargs):
+    def run(self, status__in=('Waiting',), machine=None, clobber=True, **kwargs):
         """
         Get all the session related jobs from alyx and run them
         :param status__in: lists of status strings to run in
@@ -539,9 +549,9 @@ class Pipeline(abc.ABC):
         :return: job_deck: list of REST dictionaries of the jobs endpoints
         :return: all_datasets: list of REST dictionaries of the dataset endpoints
         """
-        assert self.session_path, "Pipeline object has to be declared with a session path to run"
+        assert self.session_path, 'Pipeline object has to be declared with a session path to run'
         if self.one is None:
-            _logger.warning("No ONE instance found for Alyx connection, set the one property")
+            _logger.warning('No ONE instance found for Alyx connection, set the one property')
             return
         task_deck = self.one.alyx.rest('tasks', 'list', session=self.eid, no_cache=True)
         # [(t['name'], t['level']) for t in task_deck]
@@ -552,7 +562,7 @@ class Pipeline(abc.ABC):
             # here we update the status in-place to avoid another hit to the database
             task_deck[i], dsets = run_alyx_task(tdict=j, session_path=self.session_path,
                                                 one=self.one, job_deck=task_deck,
-                                                machine=machine, clobber=clobber)
+                                                machine=machine, clobber=clobber, **kwargs)
             if dsets is not None:
                 all_datasets.extend(dsets)
         return task_deck, all_datasets
@@ -561,8 +571,8 @@ class Pipeline(abc.ABC):
         return self.run(status__in=['Waiting', 'Held', 'Started', 'Errored', 'Empty'], **kwargs)
 
     def rerun(self, **kwargs):
-        return self.run(status__in=['Waiting', 'Held', 'Started', 'Errored', 'Empty', 'Complete', 'Incomplete'],
-                        **kwargs)
+
+        return self.run(status__in=[x for x in TASK_STATUS_SET if x != 'Abandoned'], **kwargs)
 
     @property
     def name(self):
@@ -598,14 +608,12 @@ def run_alyx_task(tdict=None, session_path=None, one=None, job_deck=None,
         parent_tasks = filter(lambda x: x['id'] in tdict['parents'], job_deck)
         parent_statuses = [j['status'] for j in parent_tasks]
         # if any of the parent tasks is not complete, throw a warning
-        if any(map(lambda s: s not in ['Complete', 'Incomplete'], parent_statuses)):
+        if not set(parent_statuses) <= {'Complete', 'Incomplete'}:
             _logger.warning(f"{tdict['name']} has unmet dependencies")
             # if parents are waiting or failed, set the current task status to Held
             # once the parents ran, the descendent tasks will be set from Held to Waiting (see below)
-            if any(map(lambda s: s in ['Errored', 'Held', 'Empty', 'Waiting', 'Started', 'Abandoned'],
-                       parent_statuses)):
-                tdict = one.alyx.rest('tasks', 'partial_update', id=tdict['id'],
-                                      data={'status': 'Held'})
+            if set(parent_statuses).intersection({'Errored', 'Held', 'Empty', 'Waiting', 'Started', 'Abandoned'}):
+                tdict = one.alyx.rest('tasks', 'partial_update', id=tdict['id'], data={'status': 'Held'})
             return tdict, registered_dsets
     # creates the job from the module name in the database
     exec_name = tdict['executable']
@@ -627,8 +635,9 @@ def run_alyx_task(tdict=None, session_path=None, one=None, job_deck=None,
         try:
             kwargs = dict(one=one, max_md5_size=max_md5_size)
             if location == 'server':
-                # Explicitly pass lab as lab cannot be inferred from path
-                kwargs['labs'] = ','.join(get_lab(one.alyx))
+                # Explicitly pass lab as lab cannot be inferred from path (which the registration client tries to do).
+                # To avoid making extra REST requests we can also set labs=None if using ONE v1.20.1.
+                kwargs['labs'] = get_lab(session_path, one.alyx)
             registered_dsets = task.register_datasets(**kwargs)
             patch_data['status'] = 'Complete'
         except Exception:
@@ -639,10 +648,10 @@ def run_alyx_task(tdict=None, session_path=None, one=None, job_deck=None,
     if status == -1:
         patch_data['status'] = 'Errored'
     # Status -2 means a lock was encountered during run, should be rerun
-    if status == -2:
+    elif status == -2:
         patch_data['status'] = 'Waiting'
     # Status -3 should be returned if a task is Incomplete
-    if status == -3:
+    elif status == -3:
         patch_data['status'] = 'Incomplete'
     # update task status on Alyx
     t = one.alyx.rest('tasks', 'partial_update', id=tdict['id'], data=patch_data)
@@ -654,7 +663,7 @@ def run_alyx_task(tdict=None, session_path=None, one=None, job_deck=None,
         assert d['id'] != t['id'], 'task its own parent'
         # if all their parent tasks now complete, set to waiting
         parent_status = [next(x['status'] for x in job_deck if x['id'] == y) for y in d['parents']]
-        if all(x in ['Complete', 'Incomplete'] for x in parent_status):
+        if set(parent_status) <= {'Complete', 'Incomplete'}:
             one.alyx.rest('tasks', 'partial_update', id=d['id'], data={'status': 'Waiting'})
     task.cleanUp()
     if mode == 'raise' and status != 0:

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -387,7 +387,7 @@ class Pipeline(abc.ABC):
         if one and one.alyx.cache_mode and one.alyx.default_expiry.seconds > 1:
             _logger.warning('Alyx client REST cache active; this may cause issues with jobs')
         self.eid = eid
-        self.data_repo = get_local_data_repository(self.one)
+        self.data_repo = get_local_data_repository(self.one.alyx)
         if session_path:
             self.session_path = session_path
             if not self.eid:

--- a/ibllib/pipes/training_status.py
+++ b/ibllib/pipes/training_status.py
@@ -133,10 +133,19 @@ def load_combined_trials(sess_paths, one):
 
 def get_latest_training_information(sess_path, one):
     """
-    Extracts the latest training status
-    :param sess_path:
-    :param one:
-    :return:
+    Extracts the latest training status.
+
+    Parameters
+    ----------
+    sess_path : pathlib.Path
+        The session path from which to load the data.
+    one : one.api.One
+        An ONE instance.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A table of training information.
     """
 
     subj_path = sess_path.parent.parent

--- a/ibllib/tests/test_oneibl.py
+++ b/ibllib/tests/test_oneibl.py
@@ -39,7 +39,8 @@ class TestUtils(unittest.TestCase):
         # Should find intersection based on labs with endpoint ID
         subjects = [{'lab': 'bar'}, {'lab': 'baz'}]
         data_repo_labs = [{'name': 'baz'}, {'name': 'foobar'}]
-        with mock.patch.object(alyx, 'rest', side_effect=[subjects, data_repo_labs]):
+        with mock.patch.object(alyx, 'rest', side_effect=[subjects, data_repo_labs]), \
+                mock.patch('one.remote.globus.get_local_endpoint_id'):
             self.assertEqual('baz', registration.get_lab(session_path, alyx))
 
 

--- a/ibllib/tests/test_tasks.py
+++ b/ibllib/tests/test_tasks.py
@@ -169,7 +169,7 @@ class TestPipelineAlyx(unittest.TestCase):
 
     @mock.patch('ibllib.pipes.tasks.get_lab')
     def test_pipeline_alyx(self, mock_ep):
-        mock_ep().get.return_value = ['cortexlab']
+        mock_ep.return_value = 'cortexlab'
         eid = self.eid
         pipeline = SomePipeline(self.session_path, one=one, eid=eid)
 


### PR DESCRIPTION
`get_lab` uses the subjects endpoint to get lab name, instead of endpoint id so that only one set of file records are created on the floferlab local server.  Passing the lab name was required because the ONE RegistrationClient tries to infer the lab name from the path, which for local lab servers is invalid.  I've also changed ONE so that if 'labs' is a keyword arg it doesn't try to infer the lab from the path, even if the value is None.

Also removed the redundant `get_local_data_repository` function data_handlers.

The other changes are mostly pointless style changes.