### PR TITLE
Atlas fix

### DIFF
--- a/ibllib/atlas/atlas.py
+++ b/ibllib/atlas/atlas.py
@@ -295,6 +295,9 @@ class BrainAtlas:
         :param mapping: brain region mapping (defaults to original Allen mapping)
         :param radius_um: if not null, returns a regions ids array and an array of proportion
          of regions in a sphere of size radius around the coordinates.
+        :param mode: {‘raise’, 'clip'} determines what to do when determined index lies outside the atlas volume
+        'raise' will raise a ValueError (default)
+        'clip' will replace the index with the closest index inside the volume
         :return: n array of region ids
         """
         mapping = mapping or self.regions.default_mapping
@@ -304,7 +307,7 @@ class BrainAtlas:
             nry = int(np.ceil(radius_um / abs(self.bc.dy) / 1e6))
             nrz = int(np.ceil(radius_um / abs(self.bc.dz) / 1e6))
             nr = [nrx, nry, nrz]
-            iii = self.bc.xyz2i(xyz)
+            iii = self.bc.xyz2i(xyz, mode=mode)
             # computing the cube radius and indices is more complicated as volume indices are not
             # necessariy in ml, ap, dv order so the indices order is dynamic
             rcube = np.meshgrid(*tuple((np.arange(

--- a/ibllib/atlas/atlas.py
+++ b/ibllib/atlas/atlas.py
@@ -1077,21 +1077,25 @@ class AllenAtlas(BrainAtlas):
         else:
             ValueError("ccf_order needs to be either 'mlapdv' or 'apdvml'")
 
-    def compute_regions_volume(self):
+    def compute_regions_volume(self, cumsum=False):
         """
         Sums the number of voxels in the labels volume for each region.
         Then compute volumes for all of the levels of hierarchy in cubic mm.
+        :param: cumsum: computes the cumulative sum of the volume as per the hierarchy (defaults to False)
         :return:
         """
         nr = self.regions.id.shape[0]
         count = np.bincount(self.label.flatten(), minlength=nr)
-        self.regions.compute_hierarchy()
-        self.regions.volume = np.zeros_like(count)
-        for i in np.arange(nr):
-            if count[i] == 0:
-                continue
-            self.regions.volume[np.unique(self.regions.hierarchy[:, i])] += count[i]
-        self.regions.volume = self.regions.volume * (self.res_um / 1e3) ** 3
+        if not cumsum:
+            self.regions.volume = count * (self.res_um / 1e3) ** 3
+        else:
+            self.regions.compute_hierarchy()
+            self.regions.volume = np.zeros_like(count)
+            for i in np.arange(nr):
+                if count[i] == 0:
+                    continue
+                self.regions.volume[np.unique(self.regions.hierarchy[:, i])] += count[i]
+            self.regions.volume = self.regions.volume * (self.res_um / 1e3) ** 3
 
 
 def NeedlesAtlas(*args, **kwargs):

--- a/ibllib/atlas/regions.py
+++ b/ibllib/atlas/regions.py
@@ -24,11 +24,19 @@ class _BrainRegions:
     parent: np.ndarray
     order: np.uint16
 
+    def to_df(self):
+        d = {at: self.__getattribute__(at) for at in ['id', 'name', 'acronym', 'hexcolor', 'level', 'parent', 'order']}
+        return pd.DataFrame(d)
+
     @property
     def rgba(self):
         rgba = np.c_[self.rgb, self.rgb[:, 0] * 0 + 255]
         rgba[0, :] = 0  # set the void to transparent
         return rgba
+
+    @property
+    def hexcolor(self):
+        return np.apply_along_axis(lambda x: "#{0:02x}{1:02x}{2:02x}".format(*x.astype(int)), 1, self.rgb)
 
     def _compute_order(self):
         """

--- a/ibllib/io/session_params.py
+++ b/ibllib/io/session_params.py
@@ -470,7 +470,7 @@ def prepare_experiment(session_path, acquisition_description=None, local=None, r
         return
     # Determine if user passed in arg for local/remote subject folder locations or pull in from
     # local param file or prompt user if missing
-    params = misc.create_basic_transfer_params(transfers_path=local, remote_data_path=remote)
+    params = misc.create_basic_transfer_params(local_data_path=local, remote_data_path=remote)
 
     # First attempt to copy to server
     local_only = remote is False or params.get('REMOTE_DATA_FOLDER_PATH', False) is False

--- a/ibllib/tests/test_atlas.py
+++ b/ibllib/tests/test_atlas.py
@@ -28,6 +28,15 @@ class TestBrainRegions(unittest.TestCase):
     def setUpClass(self):
         self.brs = BrainRegions()
 
+    def test_to_df(self):
+        df = self.brs.to_df()
+        self.assertTrue(df.shape[0] == self.brs.acronym.shape[0])
+        self.assertEqual(
+            set(['id', 'name', 'acronym', 'hexcolor', 'level', 'parent', 'order']), set(list(df.columns)))
+
+    def test_hexcolor(self):
+        assert self.brs.hexcolor.shape == (self.brs.rgb.shape[0],)
+
     def test_rgba(self):
         assert self.brs.rgba.shape == (self.brs.rgb.shape[0], 4)
 

--- a/ibllib/tests/test_atlas.py
+++ b/ibllib/tests/test_atlas.py
@@ -366,6 +366,12 @@ class TestAtlasSlicesConversion(unittest.TestCase):
         self.assertTrue(np.allclose(self.ba.bc.xyz2i(np.array([0, 0, 0]), round=False),
                                     ALLEN_CCF_LANDMARKS_MLAPDV_UM['bregma'] / 25))
 
+    def test_lookup_outside_the_brain(self):
+        xyz = [0, 0, 15687588]
+        with self.assertRaises(ValueError):
+            self.ba.get_labels(xyz)
+        self.assertEqual(self.ba.get_labels(xyz, mode='clip'), 0)
+
     def test_lookups(self):
         # the get_labels lookup returns the regions ids (not the indices !!)
         assert self.ba.get_labels([0, 0, self.ba.bc.i2z(103)]) == 304325711

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -535,11 +535,11 @@ class TestSessionParams(unittest.TestCase):
         self.assertTrue(len(data['devices'].keys()) > 1)
 
         # A device with another identical sync key
-        file_device = self.devices_path.joinpath(f'ephys.yaml')
+        file_device = self.devices_path.joinpath('ephys.yaml')
         session_params.aggregate_device(file_device, fullfile, unlink=True)
 
         # A device with a different sync
-        file_device = self.devices_path.joinpath(f'sync.yaml')
+        file_device = self.devices_path.joinpath('sync.yaml')
         with self.assertRaises(AssertionError):
             session_params.aggregate_device(file_device, fullfile, unlink=True)
 


### PR DESCRIPTION
A few minor fix and a larger one concerning the volume computation.

By default we reverted to a simple sum of voxels per acronym, leaving the task of computing the cumulative volume up the region hierarchy to the user.