### PR TITLE
Fix typo in criterion_ephys; documentation

### DIFF
--- a/ibllib/__init__.py
+++ b/ibllib/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 
-__version__ = '2.26'
+__version__ = '2.26.1'
 warnings.filterwarnings('always', category=DeprecationWarning, module='ibllib')
 
 # if this becomes a full-blown library we should let the logging configuration to the discretion of the dev

--- a/release_notes.md
+++ b/release_notes.md
@@ -3,6 +3,9 @@
 ### features
 - Deprecate ibllib.atlas. Code now contained in package iblatlas
 
+### bugfixes
+### 2.26.1
+- fix typo in criterion_ephys where lapse high for 0.8 blocks only passed when non-zero.
 
 ## Release Notes 2.25
 
@@ -12,7 +15,7 @@
 - Full photometry lookup table 
 
 ### bugfixes
-- fix for untrainable, unbiasable don't repolulate if already exists
+- fix for untrainable, unbiasable don't repopulate if already exists
 ### 2.25.1
 - relax assertion on Neuropixel channel mappings to allow for personal projects
 ### 2.25.2


### PR DESCRIPTION
- Fix for incorrect ready4ephysrig and ready4recording for 0.8 block lapse high criterion.
- Docstrings of all functions in brainbox.behavior.training module.
- Simplified alpha input parameter
- Criteria written for each training status test function.
- Added examples for calculating 'reaction times' in various ways.
- Detailed notes on 'reaction/response time' definition, psychometric constraints and fit parameter thresholds that address various user comments.