### PR TITLE
`brainbox.single_unit.quick_unit_metrics` SRP fix

### DIFF
--- a/brainbox/metrics/single_units.py
+++ b/brainbox/metrics/single_units.py
@@ -981,7 +981,7 @@ def quick_unit_metrics(spike_clusters, spike_times, spike_amps, spike_depths,
     r.amp_std_dB[ir] = np.array(camp['log_amps'].std())
     srp = metrics.slidingRP_all(spikeTimes=spike_times, spikeClusters=spike_clusters,
                                 **{'sampleRate': 30000, 'binSizeCorr': 1 / 30000})
-    r.slidingRP_viol[srp['cidx']] = srp['value']
+    r.slidingRP_viol = srp['value']
 
     # loop over each cluster to compute the rest of the metrics
     for ic in np.arange(nclust):

--- a/brainbox/metrics/single_units.py
+++ b/brainbox/metrics/single_units.py
@@ -981,7 +981,7 @@ def quick_unit_metrics(spike_clusters, spike_times, spike_amps, spike_depths,
     r.amp_std_dB[ir] = np.array(camp['log_amps'].std())
     srp = metrics.slidingRP_all(spikeTimes=spike_times, spikeClusters=spike_clusters,
                                 **{'sampleRate': 30000, 'binSizeCorr': 1 / 30000})
-    r.slidingRP_viol = srp['value']
+    r.slidingRP_viol[ir] = srp['value']
 
     # loop over each cluster to compute the rest of the metrics
     for ic in np.arange(nclust):


### PR DESCRIPTION
The `slidingRP_all` returns a list of cluster ids, *not* contiguous indices as the `"cidx"` field. So when the cluster ids are not contiguous (i.e. manually corrected kilosort output) the following line has an index out of range error:

https://github.com/int-brain-lab/ibllib/blob/f1d3a1003ddf0702d5bc84a8e13cc0dbd49c9932/brainbox/metrics/single_units.py#L984

The indices in `"cidx"` are greater than the total size of the unique clusters array. Since the cluster ids are returned in the order we want (sorted), we don't need to index here and can avoid the bug (we filter by the `ir` mask to account for clusters with no spikes)

cf. 

https://github.com/SteinmetzLab/slidingRefractory/blob/af27845a7b040acfd6dfe461bba43ecf940a1077/python/slidingRP/metrics.py#L116

The cluster ids will be returned sorted