### PR TITLE
hotfix/2.32.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ seaborn>=0.9.0
 tqdm>=4.32.1
 # ibl libraries
 iblatlas>=0.4.0
-ibl-neuropixel>=0.8.1
+ibl-neuropixel>=0.9.2
 iblutil>=1.7.0
 mtscomp>=1.0.1
 ONE-api>=2.6


### PR DESCRIPTION
The required ibl-neuropixel version needs to be increased to accommodate the switch from neurodsp to ibldsp