### PR TITLE
Minor fixes to IBL registration client

### DIFF
--- a/ibllib/__init__.py
+++ b/ibllib/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 
-__version__ = '2.32.4'
+__version__ = '2.32.5'
 warnings.filterwarnings('always', category=DeprecationWarning, module='ibllib')
 
 # if this becomes a full-blown library we should let the logging configuration to the discretion of the dev

--- a/ibllib/io/session_params.py
+++ b/ibllib/io/session_params.py
@@ -169,9 +169,9 @@ def merge_params(a, b, copy=False):
         if k == 'sync':
             assert k not in a or a[k] == b[k], 'multiple sync fields defined'
         if isinstance(b[k], list):
-            prev = a.get(k, [])
+            prev = list(a.get(k, []))
             # For procedures and projects, remove duplicates
-            to_add = b[k] if k == 'tasks' else set(prev) ^ set(b[k])
+            to_add = b[k] if k == 'tasks' else set(b[k]) - set(prev)
             a[k] = prev + list(to_add)
         elif isinstance(b[k], dict):
             a[k] = {**a.get(k, {}), **b[k]}

--- a/ibllib/tests/test_io.py
+++ b/ibllib/tests/test_io.py
@@ -555,6 +555,23 @@ class TestSessionParams(unittest.TestCase):
         collections = session_params.get_collections(tasks, flat=True)
         self.assertEqual(collections, {'raw_passive_data_bis', 'raw_passive_data', 'raw_behavior_data'})
 
+    def test_merge_params(self):
+        """Test for ibllib.io.session_params.merge_params functions."""
+        a = self.fixture
+        b = {'procedures': ['Imaging', 'Injection'], 'tasks': [{'fooChoiceWorld': {'collection': 'bar'}}]}
+        c = session_params.merge_params(a, b, copy=True)
+        self.assertCountEqual(['Imaging', 'Behavior training/tasks', 'Injection'], c['procedures'])
+        self.assertCountEqual(['passiveChoiceWorld', 'ephysChoiceWorld', 'fooChoiceWorld'], (list(x)[0] for x in c['tasks']))
+        # Ensure a and b not modified
+        self.assertNotEqual(set(c['procedures']), set(a['procedures']))
+        self.assertNotEqual(set(a['procedures']), set(b['procedures']))
+        # Test without copy
+        session_params.merge_params(a, b, copy=False)
+        self.assertCountEqual(['Imaging', 'Behavior training/tasks', 'Injection'], a['procedures'])
+        # Test assertion on duplicate sync
+        b['sync'] = {'foodaq': {'collection': 'raw_sync_data'}}
+        self.assertRaises(AssertionError, session_params.merge_params, a, b)
+
 
 class TestRawDaqLoaders(unittest.TestCase):
     """Tests for raw_daq_loaders module"""

--- a/ibllib/tests/test_oneibl.py
+++ b/ibllib/tests/test_oneibl.py
@@ -429,9 +429,12 @@ class TestRegistration(unittest.TestCase):
                               query_type='remote')[0]
         ses_info = self.one.alyx.rest('sessions', 'read', id=eid)
         self.assertTrue(ses_info['procedures'] == ['Behavior training/tasks'])
-        self.one.alyx.rest('sessions', 'delete', id=eid)
-        # re-register the session as unknown protocol this time
+        # re-register the session as unknown protocol, this time without removing session first
         self.settings['PYBPOD_PROTOCOL'] = 'gnagnagna'
+        # also add an end time
+        start = datetime.datetime.fromisoformat(self.settings['SESSION_DATETIME'])
+        self.settings['SESSION_START_TIME'] = rc.ensure_ISO8601(start)
+        self.settings['SESSION_END_TIME'] = rc.ensure_ISO8601(start + datetime.timedelta(hours=1))
         with open(settings_file, 'w') as fid:
             json.dump(self.settings, fid)
         rc.register_session(self.session_path)
@@ -439,6 +442,7 @@ class TestRegistration(unittest.TestCase):
                               query_type='remote')[0]
         ses_info = self.one.alyx.rest('sessions', 'read', id=eid)
         self.assertTrue(ses_info['procedures'] == [])
+        self.assertEqual(self.settings['SESSION_END_TIME'], ses_info['end_time'])
         self.one.alyx.rest('sessions', 'delete', id=eid)
 
     def test_register_chained_session(self):
@@ -457,12 +461,13 @@ class TestRegistration(unittest.TestCase):
 
         # Save experiment description
         session_params.write_params(self.session_path, experiment_description)
-
+        self.settings['POOP_COUNT'] = 10
         with open(behaviour_paths[1].joinpath('_iblrig_taskSettings.raw.json'), 'w') as fid:
             json.dump(self.settings, fid)
 
         settings = self.settings.copy()
         settings['PYBPOD_PROTOCOL'] = '_iblrig_tasks_passiveChoiceWorld'
+        settings['POOP_COUNT'] = 53
         start_time = (datetime.datetime.fromisoformat(settings['SESSION_DATETIME']) -
                       datetime.timedelta(hours=1, minutes=2, seconds=12))
         settings['SESSION_DATETIME'] = start_time.isoformat()
@@ -475,7 +480,9 @@ class TestRegistration(unittest.TestCase):
         ses_info = self.one.alyx.rest('sessions', 'read', id=session['id'])
         self.assertCountEqual(experiment_description['procedures'], ses_info['procedures'])
         self.assertCountEqual(experiment_description['projects'], ses_info['projects'])
-        self.assertCountEqual({'IS_MOCK': False, 'IBLRIG_VERSION': None}, ses_info['json'])
+        # Poo count should be sum of values in both settings files
+        expected = {'IS_MOCK': False, 'IBLRIG_VERSION': '5.4.1', 'POOP_COUNT': 63}
+        self.assertDictEqual(expected, ses_info['json'])
         self.assertEqual('2018-04-01T11:46:14.795526', ses_info['start_time'])
         # Test task protocol
         expected = '_iblrig_tasks_passiveChoiceWorld5.4.1/_iblrig_tasks_ephysChoiceWorld5.4.1'

--- a/release_notes.md
+++ b/release_notes.md
@@ -13,6 +13,9 @@
 #### 2.32.4
 - Add support for variations of the biaseCW task in the json task description
 
+#### 2.32.5
+- Minor fixes to IBL registion client, including use of SESSION_END_TIME key
+
 ## Release Notes 2.31
 
 ### features


### PR DESCRIPTION
Fixes related to int-brain-lab/iblrig#621: 
- re-registration will update n_trials and n_complete_trials
- SESSION_END_TIME key used if present
- fix bug in merge parameters where duplicate procedures included in merge
- test that poo count correctly updated
- support sessions where PYBPOD_CREATOR key is (None, '')