### PR TITLE
Correct typo in `load_raw_ephys_data`

### DIFF
--- a/examples/loading_data/loading_raw_ephys_data.ipynb
+++ b/examples/loading_data/loading_raw_ephys_data.ipynb
@@ -107,13 +107,13 @@
     "print(f'raw AP band sample for event at time {t_event}: {s_event}')\n",
     "\n",
     "# get the AP data surrounding samples\n",
-    "window_secs_ap = [-0.05, 0.05]  # we'll look at 100ms before the event and 200ms after the event for AP\n",
+    "window_secs_ap = [-0.05, 0.05]  # we'll look at 50ms before and after the event for AP\n",
     "first, last = (int(window_secs_ap[0] * sr_ap.fs) + s_event, int(window_secs_ap[1] * sr_ap.fs + s_event))\n",
     "raw_ap = sr_ap[first:last, :-sr_ap.nsync].T\n",
     "\n",
     "# get the LF data surrounding samples\n",
-    "window_secs_ap = [-0.750, 0.750]  # we'll look at 100ms before the event and 200ms after the event\n",
-    "sample_lf = s_event // 12  # NB: for neuropixel probes this is always 12\n",
+    "window_secs_ap = [-0.750, 0.750]  # we'll look at 750ms before and after the event because LF varies more slowly in time\n",
+    "sample_lf = s_event // 12  # NB: for neuropixel probes this is always 12 because AP is sampled at 12x the frequency of LF\n",
     "first, last = (int(window_secs_ap[0] * sr_lf.fs) + sample_lf, int(window_secs_ap[1] * sr_lf.fs + sample_lf))\n",
     "raw_lf = sr_lf[first:last, :-sr_lf.nsync].T"
    ]


### PR DESCRIPTION
User pointed out a typo in how much time in AP and LF are being loaded for the example