### PR TITLE
CI test fixes

### DIFF
--- a/ibllib/pipes/misc.py
+++ b/ibllib/pipes/misc.py
@@ -74,7 +74,7 @@ def create_alyx_probe_insertions(
     for plabel in labels:
         insdict = {"session": eid, "name": plabel, "model": pmodel, "json": qc_dict}
         # search for the corresponding insertion in Alyx
-        alyx_insertion = one.alyx.get(f'/insertions?&session={eid}&name={plabel}', clobber=True)
+        alyx_insertion = one.alyx.get(f'/insertions?&session={str(eid)}&name={plabel}', clobber=True)
         # if it doesn't exist, create it
         if len(alyx_insertion) == 0:
             alyx_insertion = one.alyx.rest("insertions", "create", data=insdict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ibl-neuropixel>=1.6.2
 iblutil>=1.13.0
 iblqt>=0.4.2
 mtscomp>=1.0.1
-ONE-api==3.0b3
+ONE-api==3.0b4
 phylib>=2.6.0
 psychofit
 slidingRP>=1.1.1  # steinmetz lab refractory period metrics


### PR DESCRIPTION
Changes in ONE v3.0b4 should allow UUID objects in both REST filters and PUT/PATCH data. These changes are for the Django query strings.