### PR TITLE
add options for SDSC and EC2 patchers

### DIFF
--- a/ibllib/oneibl/data_handlers.py
+++ b/ibllib/oneibl/data_handlers.py
@@ -16,7 +16,7 @@ from copy import copy
 from one.api import ONE
 from one.webclient import AlyxClient
 from one.util import filter_datasets
-from one.alf.path import add_uuid_string, session_path_parts, get_alf_path
+from one.alf.path import add_uuid_string, get_alf_path, ensure_alf_path
 from one.alf.cache import _make_datasets_df
 from iblutil.util import flatten, ensure_list
 
@@ -549,7 +549,7 @@ class DataHandler(abc.ABC):
         :param signature: input and output file signatures
         :param one: ONE instance
         """
-        self.session_path = session_path
+        self.session_path = ensure_alf_path(session_path)
         self.signature = _parse_signature(signature)
         self.one = one
         self.processed = {}  # Map of filepaths and their processed records (e.g. upload receipts or Alyx records)
@@ -728,7 +728,7 @@ class ServerGlobusDataHandler(DataHandler):
             _logger.warning('Space left on server is < 500GB, won\'t re-download new data')
             return
 
-        rel_sess_path = '/'.join(self.session_path.parts[-3:])
+        rel_sess_path = self.session_path.session_path_short()
         target_paths = []
         source_paths = []
         for i, d in df.iterrows():
@@ -858,7 +858,7 @@ class RemoteAwsDataHandler(DataHandler):
         # Set up Globus
         from one.remote.globus import Globus # noqa
         self.globus = Globus(client_name=kwargs.pop('client_name', 'server'), headless=True)
-        self.lab = session_path_parts(self.session_path, as_dict=True)['lab']
+        self.lab = self.session_path.lab
         if self.lab == 'cortexlab' and 'cortexlab' in self.one.alyx.base_url:
             base_url = 'https://alyx.internationalbrainlab.org'
             _logger.warning('Changing Alyx client to %s', base_url)
@@ -971,21 +971,23 @@ class SDSCDataHandler(DataHandler):
         super().__init__(session_path, signatures, one=one)
         self.patch_path = os.getenv('SDSC_PATCH_PATH', SDSC_PATCH_PATH)
         self.root_path = SDSC_ROOT_PATH
+        self.linked_files = []  # List of symlinks created to run tasks
 
     def setUp(self, task, **_):
         """Function to create symlinks to necessary data to run tasks."""
         df = super().getData()
 
-        SDSC_TMP = Path(self.patch_path.joinpath(task.__class__.__name__))
+        SDSC_TMP = ensure_alf_path(self.patch_path.joinpath(task.__class__.__name__))
         session_path = Path(get_alf_path(self.session_path))
         for uuid, d in df.iterrows():
             file_path = session_path / d['rel_path']
             file_uuid = add_uuid_string(file_path, uuid)
             file_link = SDSC_TMP.joinpath(file_path)
             file_link.parent.mkdir(exist_ok=True, parents=True)
-            try:
+            try:  # TODO append link to task attribute
                 file_link.symlink_to(
                     Path(self.root_path.joinpath(file_uuid)))
+                self.linked_files.append(file_link)
             except FileExistsError:
                 pass
         task.session_path = SDSC_TMP.joinpath(session_path)

--- a/ibllib/oneibl/data_handlers.py
+++ b/ibllib/oneibl/data_handlers.py
@@ -989,8 +989,10 @@ class SDSCDataHandler(DataHandler):
             except FileExistsError:
                 pass
         task.session_path = SDSC_TMP.joinpath(session_path)
+        # If one of the symlinked input files is also an expected output, raise here to avoid overwriting
+        # In the future we may instead copy the data under this condition
         assert self.getOutputFiles(session_path=task.session_path).shape[0] == 0, (
-            "On SDSC patcher, input files output files should be distinct from input files to avoid overwriting")
+            "On SDSC patcher, output files should be distinct from input files to avoid overwriting")
 
     def uploadData(self, outputs, version, **kwargs):
         """

--- a/ibllib/oneibl/patcher.py
+++ b/ibllib/oneibl/patcher.py
@@ -675,11 +675,11 @@ class S3Patcher(Patcher):
 
         return exists
 
-    def patch_dataset(self, file_list, dry=False, ftp=False, force=False, **kwargs):
+    def patch_dataset(self, file_list, dry=False, ftp=False, clobber=False, **kwargs):
 
         exists = self.check_datasets(file_list)
-        if len(exists) > 0 and not force:
-            _logger.error(f'Files: {", ".join([f.name for f in file_list])} already exist, to force set force=True')
+        if len(exists) > 0 and not clobber:
+            _logger.error(f'Files: {", ".join([f.name for f in file_list])} already exist, to overwrite set clobber=True')
             return
 
         response = super().patch_dataset(file_list, dry=dry, repository=self.s3_repo, ftp=False, **kwargs)

--- a/ibllib/oneibl/patcher.py
+++ b/ibllib/oneibl/patcher.py
@@ -675,11 +675,11 @@ class S3Patcher(Patcher):
 
         return exists
 
-    def patch_dataset(self, file_list, dry=False, ftp=False, clobber=False, **kwargs):
+    def patch_dataset(self, file_list, dry=False, ftp=False, force=False, **kwargs):
 
         exists = self.check_datasets(file_list)
-        if len(exists) > 0 and not clobber:
-            _logger.error(f'Files: {", ".join([f.name for f in file_list])} already exist, to overwrite set clobber=True')
+        if len(exists) > 0 and not force:
+            _logger.error(f'Files: {", ".join([f.name for f in file_list])} already exist, to overwrite set force=True')
             return
 
         response = super().patch_dataset(file_list, dry=dry, repository=self.s3_repo, ftp=False, **kwargs)

--- a/ibllib/oneibl/registration.py
+++ b/ibllib/oneibl/registration.py
@@ -10,8 +10,9 @@ from one.alf.path import get_session_path, folder_parts, get_alf_path
 from one.registration import RegistrationClient, get_dataset_type
 from one.remote.globus import get_local_endpoint_id, get_lab_from_endpoint_id
 from one.webclient import AlyxClient, no_cache
-from one.converters import ConversionMixin, datasets2records
+from one.converters import datasets2records
 import one.alf.exceptions as alferr
+from one.alf.path import ensure_alf_path
 from one.api import ONE
 from iblutil.util import ensure_list
 
@@ -553,12 +554,13 @@ def get_lab(session_path, alyx=None):
     one.remote.globus.get_lab_from_endpoint_id
     """
     alyx = alyx or AlyxClient()
-    if not (ref := ConversionMixin.path2ref(session_path)):
+    session_path = ensure_alf_path(session_path)
+    if not session_path.is_session_path():
         raise ValueError(f'Failed to parse session path: {session_path}')
 
-    labs = [x['lab'] for x in alyx.rest('subjects', 'list', nickname=ref['subject'])]
+    labs = [x['lab'] for x in alyx.rest('subjects', 'list', nickname=session_path.subject)]
     if len(labs) == 0:
-        raise alferr.AlyxSubjectNotFound(ref['subject'])
+        raise alferr.AlyxSubjectNotFound(session_path.subject)
     elif len(labs) > 1:  # More than one subject with this nickname
         # use local endpoint ID to find the correct lab
         endpoint_labs = get_lab_from_endpoint_id(alyx=alyx)

--- a/ibllib/pipes/base_tasks.py
+++ b/ibllib/pipes/base_tasks.py
@@ -62,18 +62,16 @@ class DynamicTask(Task):
         return collection_map.get(device)
 
     def read_params_file(self):
-        params = sess_params.read_params(self.session_path)
+        """Read the session parameters file.
 
-        if params is None:
+        Returns
+        -------
+        dict
+            The session parameters dictionary, or an empty dictionary if the file does not exist.
+        """
+        if not self.session_path:
             return {}
-
-        # TODO figure out the best way
-        # if params is None and self.one:
-        #     # Try to read params from alyx or try to download params file
-        #     params = self.one.load_dataset(self.one.path2eid(self.session_path), 'params.yml')
-        #     params = self.one.alyx.rest()
-
-        return params
+        return sess_params.read_params(self.session_path) or {}
 
 
 class BehaviourTask(DynamicTask):

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -377,7 +377,7 @@ class Task(abc.ABC):
         self.output_files = signature['output_files']
 
     @abc.abstractmethod
-    def _run(self, overwrite=False):
+    def _run(self, overwrite=False, **kwargs):
         """Execute main task code.
 
         This method contains a task's principal data processing code and should implemented
@@ -422,14 +422,14 @@ class Task(abc.ABC):
                 # Attempts to download missing data using globus
                 _logger.info('Not all input files found locally: attempting to re-download required files')
                 self.data_handler = self.get_data_handler(location='serverglobus')
-                self.data_handler.setUp(task=self)
+                self.data_handler.setUp(task=self, **kwargs)
                 # Double check we now have the required files to run the task
                 # TODO in future should raise error if even after downloading don't have the correct files
                 self.assert_expected_inputs(raise_error=False)
                 return True
         else:
             self.data_handler = self.get_data_handler()
-            self.data_handler.setUp(task=self)
+            self.data_handler.setUp(task=self, **kwargs)
             self.get_signatures(**kwargs)
             self.assert_expected_inputs(raise_error=False)
             return True

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -91,7 +91,7 @@ import one.params
 from one.api import ONE
 from one import webclient
 import one.alf.io as alfio
-from one.alf.path import ALFPath
+from one.alf.path import ALFPath, ensure_alf_path
 
 _logger = logging.getLogger(__name__)
 TASK_STATUS_SET = {'Waiting', 'Held', 'Started', 'Errored', 'Empty', 'Complete', 'Incomplete', 'Abandoned'}
@@ -134,7 +134,7 @@ class Task(abc.ABC):
         self.on_error = on_error
         self.taskid = taskid
         self.one = one
-        self.session_path = session_path
+        self.session_path = ensure_alf_path(session_path)
         self.register_kwargs = {}
         if parents:
             self.parents = parents

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -134,7 +134,7 @@ class Task(abc.ABC):
         self.on_error = on_error
         self.taskid = taskid
         self.one = one
-        self.session_path = ensure_alf_path(session_path)
+        self.session_path = ensure_alf_path(session_path) if session_path else None
         self.register_kwargs = {}
         if parents:
             self.parents = parents

--- a/ibllib/tests/test_base_tasks.py
+++ b/ibllib/tests/test_base_tasks.py
@@ -99,7 +99,7 @@ class TestBehaviourTask(unittest.TestCase):
     def test_get_task_collection(self) -> None:
         """Test for BehaviourTask.get_task_collection method."""
         params = {'tasks': [{'fooChoiceWorld': {'collection': 'raw_task_data_00'}}]}
-        task = ChoiceWorldTrialsBpod('')
+        task = ChoiceWorldTrialsBpod(None)
         self.assertIsNone(task.get_task_collection())
         task.session_params = params
         self.assertEqual('raw_task_data_00', task.get_task_collection())
@@ -109,7 +109,7 @@ class TestBehaviourTask(unittest.TestCase):
 
     def test_get_protocol(self) -> None:
         """Test for BehaviourTask.get_protocol method."""
-        task = ChoiceWorldTrialsBpod('')
+        task = ChoiceWorldTrialsBpod(None)
         self.assertIsNone(task.get_protocol())
         self.assertEqual('foobar', task.get_protocol(protocol='foobar'))
         task.session_params = {'tasks': [{'fooChoiceWorld': {'collection': 'raw_task_data_00'}}]}
@@ -125,7 +125,7 @@ class TestBehaviourTask(unittest.TestCase):
             {'fooChoiceWorld': {'collection': 'raw_task_data_00', 'protocol_number': 0}},
             {'barChoiceWorld': {'collection': 'raw_task_data_01', 'protocol_number': 1}}
         ]}
-        task = ChoiceWorldTrialsBpod('')
+        task = ChoiceWorldTrialsBpod(None)
         self.assertIsNone(task.get_protocol_number())
         self.assertRaises(ValueError, task.get_protocol_number, number='foo')
         self.assertEqual(1, task.get_protocol_number(number=1))
@@ -136,7 +136,7 @@ class TestBehaviourTask(unittest.TestCase):
 
     def test_assert_trials_data(self):
         """Test for BehaviourTask._assert_trials_data method."""
-        task = ChoiceWorldTrialsBpod('')
+        task = ChoiceWorldTrialsBpod(None)
         trials_data = {'foo': [1, 2, 3]}
 
         def _set(**_):

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ ibl-neuropixel>=1.6.2
 iblutil>=1.13.0
 iblqt>=0.4.2
 mtscomp>=1.0.1
-ONE-api>=3.0.0
+ONE-api>=3.2.0
 phylib>=2.6.0
 psychofit
 slidingRP>=1.1.1  # steinmetz lab refractory period metrics


### PR DESCRIPTION
During the patching of the wheel data, I needed some more control of patching using EC2 and SDSC.

- SDSC patcher operates on symlinks, and if one of the input files is modified, this directly impacts the original data. I have set an assertion that enforces distinct input and output datasets
- the EC2 patcher didn't check file hashes on checking local data, I've set it to true by default and provided an option to opt-out for bulky input data such as spike sorting. `task.run(hash_files=False)`