### PR TITLE
Update extended QC with task number prefix

### DIFF
--- a/ibllib/__init__.py
+++ b/ibllib/__init__.py
@@ -2,7 +2,7 @@
 import logging
 import warnings
 
-__version__ = '3.4.0-dev1'
+__version__ = '3.4.0-dev2'
 warnings.filterwarnings('always', category=DeprecationWarning, module='ibllib')
 
 # if this becomes a full-blown library we should let the logging configuration to the discretion of the dev

--- a/ibllib/pipes/behavior_tasks.py
+++ b/ibllib/pipes/behavior_tasks.py
@@ -99,7 +99,8 @@ class HabituationTrialsBpod(base_tasks.BehaviourTask):
         trials_data = self._assert_trials_data(trials_data)  # validate trials data
 
         # Compile task data for QC
-        qc = HabituationQC(self.session_path, one=self.one)
+        ns = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
+        qc = HabituationQC(self.session_path, namespace=ns, one=self.one)
         qc.extractor = TaskQCExtractor(self.session_path)
 
         # Update extractor fields
@@ -108,8 +109,7 @@ class HabituationTrialsBpod(base_tasks.BehaviourTask):
         qc.extractor.audio_ttls = self.extractor.audio  # used in iblapps QC viewer
         qc.extractor.settings = self.extractor.settings
 
-        namespace = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
-        qc.run(update=update, namespace=namespace)
+        qc.run(update=update)
         return qc
 
 
@@ -389,7 +389,8 @@ class ChoiceWorldTrialsBpod(base_tasks.BehaviourTask):
         if not QC:
             QC = HabituationQC if type(self.extractor).__name__ == 'HabituationTrials' else TaskQC
             _logger.debug('Running QC with %s.%s', QC.__module__, QC.__name__)
-        qc = QC(self.session_path, one=self.one, log=_logger)
+        namespace = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
+        qc = QC(self.session_path, namespace=namespace, one=self.one, log=_logger)
         if QC is not HabituationQC:
             qc_extractor.wheel_encoding = 'X1'
         qc_extractor.settings = self.extractor.settings
@@ -398,8 +399,7 @@ class ChoiceWorldTrialsBpod(base_tasks.BehaviourTask):
         qc.extractor = qc_extractor
 
         # Aggregate and update Alyx QC fields
-        namespace = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
-        qc.run(update=update, namespace=namespace)
+        qc.run(update=update)
         return qc
 
 
@@ -497,7 +497,8 @@ class ChoiceWorldTrialsNidq(ChoiceWorldTrialsBpod):
         if not QC:
             QC = HabituationQC if type(self.extractor).__name__ == 'HabituationTrials' else TaskQC
         _logger.debug('Running QC with %s.%s', QC.__module__, QC.__name__)
-        qc = QC(self.session_path, one=self.one, log=_logger)
+        namespace = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
+        qc = QC(self.session_path, namespace=namespace, one=self.one, log=_logger)
         if QC is not HabituationQC:
             # Add Bpod wheel data
             wheel_ts_bpod = self.extractor.bpod2fpga(self.extractor.bpod_trials['wheel_timestamps'])
@@ -511,8 +512,7 @@ class ChoiceWorldTrialsNidq(ChoiceWorldTrialsBpod):
         qc.extractor = qc_extractor
 
         # Aggregate and update Alyx QC fields
-        namespace = 'task' if self.protocol_number is None else f'task_{self.protocol_number:02}'
-        qc.run(update=update, namespace=namespace)
+        qc.run(update=update)
 
         if plot_qc:
             _logger.info('Creating Trials QC plots')

--- a/ibllib/tests/qc/test_task_metrics.py
+++ b/ibllib/tests/qc/test_task_metrics.py
@@ -43,16 +43,16 @@ class TestAggregateOutcome(unittest.TestCase):
 
     def test_outcome_from_dict_stimFreeze_delays(self):
         # For '_task_stimFreeze_delays' the threshold are 0.99 PASS and 0 WARNING
-        qc_dict = {'gnap': .99, 'gnop': np.nan, '_task_stimFreeze_delays': .1}
-        expect = {'gnap': spec.QC.PASS, 'gnop': spec.QC.NOT_SET, '_task_stimFreeze_delays': spec.QC.WARNING}
+        qc_dict = {'gnap': .99, 'gnop': np.nan, 'stimFreeze_delays': .1}
+        expect = {'gnap': spec.QC.PASS, 'gnop': spec.QC.NOT_SET, 'stimFreeze_delays': spec.QC.WARNING}
         outcome, outcome_dict = qcmetrics.compute_session_status_from_dict(qc_dict, qcmetrics.BWM_CRITERIA)
         self.assertEqual(outcome, spec.QC.WARNING)
         self.assertEqual(expect, outcome_dict)
 
     def test_outcome_from_dict_iti_delays(self):
         # For '_task_iti_delays' the threshold is 0 NOT_SET
-        qc_dict = {'gnap': .99, 'gnop': np.nan, '_task_iti_delays': .1}
-        expect = {'gnap': spec.QC.PASS, 'gnop': spec.QC.NOT_SET, '_task_iti_delays': spec.QC.NOT_SET}
+        qc_dict = {'gnap': .99, 'gnop': np.nan, 'iti_delays': .1}
+        expect = {'gnap': spec.QC.PASS, 'gnop': spec.QC.NOT_SET, 'iti_delays': spec.QC.NOT_SET}
         outcome, outcome_dict = qcmetrics.compute_session_status_from_dict(qc_dict, qcmetrics.BWM_CRITERIA)
         self.assertEqual(outcome, spec.QC.PASS)
         self.assertEqual(expect, outcome_dict)


### PR DESCRIPTION
This solves issue of task extended QC being overwritten for chained protocols.  TaskQC is now instantiated with a namespace kwarg which is set to 'task_XX' for chained protocols but is 'task' by default.