### PR TITLE
NWB conversion

### DIFF
--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -1025,11 +1025,11 @@ class SpikeSortingLoader:
          (seconds main time to samples probe time)
         :return:
         """
+        self._get_probe_info()
         fs = fs or self._sync['fs']
         fs_ratio = self._sync['fs'] / fs
         values = values * fs_ratio
-            
-        self._get_probe_info()
+
         return self._sync[direction](values)
 
     @property

--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -1017,7 +1017,7 @@ class SpikeSortingLoader:
         elif direction == 'reverse':
             return self._sync['reverse'](values) / self._sync['fs']
 
-    def samples2times(self, values, direction='forward', band='ap'):
+    def samples2times(self, values, direction='forward', fs=None):
         """
         Converts ephys sample values to session main clock seconds
         :param values: numpy array of times in seconds or samples to resync
@@ -1025,8 +1025,9 @@ class SpikeSortingLoader:
          (seconds main time to samples probe time)
         :return:
         """
-        if band == 'lf':
-            values = values * 12
+        fs = fs or self._sync['fs']
+        fs_ratio = self._sync['fs'] / fs
+        values = values * fs_ratio
             
         self._get_probe_info()
         return self._sync[direction](values)

--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -1017,7 +1017,7 @@ class SpikeSortingLoader:
         elif direction == 'reverse':
             return self._sync['reverse'](values) / self._sync['fs']
 
-    def samples2times(self, values, direction='forward'):
+    def samples2times(self, values, direction='forward', band='ap'):
         """
         Converts ephys sample values to session main clock seconds
         :param values: numpy array of times in seconds or samples to resync
@@ -1025,6 +1025,9 @@ class SpikeSortingLoader:
          (seconds main time to samples probe time)
         :return:
         """
+        if band == 'lf':
+            values = values * 12
+            
         self._get_probe_info()
         return self._sync[direction](values)
 


### PR DESCRIPTION
for the NWB conversion: the samples2times function needs to work for both LFP and AP bands, added an optional kwarg to `samples2times`