### PR TITLE
PostLP task fix

### DIFF
--- a/ibllib/pipes/base_tasks.py
+++ b/ibllib/pipes/base_tasks.py
@@ -279,7 +279,8 @@ class BehaviourTask(DynamicTask):
 
     def get_signatures(self, **kwargs):
         """ explicitly adding the experiment description file to the input files for all behavior tasks
-        This is pretty hacky but avoids having to modify all the child classes"""
+        There is a trade-off between this inheritance design and explicit file signatures for child classes"""
+
         super().get_signatures(**kwargs)
         self.input_files.append(('_ibl_experiment.description.pqt', self.collection, True))
         return super().get_signatures(**kwargs)

--- a/ibllib/pipes/base_tasks.py
+++ b/ibllib/pipes/base_tasks.py
@@ -277,8 +277,15 @@ class BehaviourTask(DynamicTask):
             raise ValueError('No trials data and/or extractor found')
         return trials_data
 
+    def get_signatures(self, **kwargs):
+        """ explicitly adding the experiment description file to the input files for all behavior tasks
+        This is pretty hacky but avoids having to modify all the child classes"""
+        super().get_signatures(**kwargs)
+        self.input_files.append(('_ibl_experiment.description.pqt', self.collection, True))
+        return super().get_signatures(**kwargs)
 
-class VideoTask(DynamicTask):
+
+class VideoTask(BehaviourTask):
 
     def __init__(self, session_path, cameras, **kwargs):
         super().__init__(session_path, cameras=cameras, **kwargs)

--- a/ibllib/pipes/video_tasks.py
+++ b/ibllib/pipes/video_tasks.py
@@ -825,7 +825,7 @@ class PostLP(base_tasks.VideoTask):
         return {
             'input_files': [(f'_ibl_{cam}Camera.lightningPose.pqt', 'alf', True) for cam in self.cameras] +
                            [(f'_ibl_{cam}Camera.times.npy', 'alf', True) for cam in self.cameras] +
-                           ['_ibl_experiment.description.pqt', self.trial_collection, True] +
+                           ['_ibl_experiment.description.yaml', self.trial_collection, True] +
             # the following are required for the LP plot only
             # they are not strictly required, some plots just might be skipped
             # In particular the raw videos don't need to be downloaded as they can be streamed

--- a/ibllib/pipes/video_tasks.py
+++ b/ibllib/pipes/video_tasks.py
@@ -818,13 +818,14 @@ class PostLP(base_tasks.VideoTask):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.trials_collection = kwargs.get('trials_collection', 'alf')
+        self.trials_collection = self.get_task_collection()
 
     @property
     def signature(self):
         return {
             'input_files': [(f'_ibl_{cam}Camera.lightningPose.pqt', 'alf', True) for cam in self.cameras] +
                            [(f'_ibl_{cam}Camera.times.npy', 'alf', True) for cam in self.cameras] +
+                           ['_ibl_experiment.description.pqt', self.trial_collection, True] +
             # the following are required for the LP plot only
             # they are not strictly required, some plots just might be skipped
             # In particular the raw videos don't need to be downloaded as they can be streamed


### PR DESCRIPTION
this fixes Matt's problem:

(from slack):
_I have a troubleshooting question that may (or may not) have a simple answer. For the PostLP task I'm working with, the signature property looks like this:_
```
    @property
    def signature(self):
        return {
            'input_files': [(f'_ibl_{cam}Camera.lightningPose.pqt', 'alf', True) for cam in self.cameras] +
                           [(f'_ibl_{cam}Camera.times.npy', 'alf', True) for cam in self.cameras] +
                           ...
                           ...
                           [('_ibl_trials.table.pqt', self.trials_collection, True),
                            ('_ibl_wheel.position.npy', self.trials_collection, True),
                            ('_ibl_wheel.timestamps.npy', self.trials_collection, True)],
```
_the problem I'm facing is that the trials_collection for some (steinmetz) sessions is alf, while for others it's alf/task_00 (and there may be others), and the current data handler (ec2) doesn't handle this gracefully_

and addresses Oliviers comment:
_Yet there will be another issue: if you are running from EC2, you need to download the experiment description file for this method to work properly. For now you can add this to the input signature of your tasks, but we were actually discussing today that we should add this for all of the tasks, ideally using the same pattern of adding this in the base classes._

by adding the `_ibl_experiment.description.pqt` to the list of input files by extending the `get_signatures()` method. Not very pretty.