### PR TITLE
small bugfix for loading experiment description files where protocols…

### DIFF
--- a/ibllib/io/session_params.py
+++ b/ibllib/io/session_params.py
@@ -31,7 +31,7 @@ from itertools import chain
 from copy import deepcopy
 
 from one.converters import ConversionMixin
-from iblutil.util import flatten
+from iblutil.util import flatten, ensure_list
 from iblutil.io.params import FileLock
 from packaging import version
 
@@ -342,7 +342,7 @@ def get_task_collection(sess_params, task_protocol=None):
     -----
     - The order of the set may not be the same as the descriptions tasks order when iterating.
     """
-    protocols = sess_params.get('tasks', [])
+    protocols = ensure_list(sess_params.get('tasks', []))
     if task_protocol is not None:
         task = next((x for x in protocols if task_protocol in x), None)
         return (task.get(task_protocol) or {}).get('collection')


### PR DESCRIPTION
… are not a list

this snippet reproduces the problem:
```
from one.api import ONE
import ibllib.io.session_params as sess_params

one = ONE()
eid = "1c61be53-cb71-469c-b2a3-304f7bb5ec2f"
ed = one.load_dataset(eid, '*experiment.description')
sess_params.get_task_collection(ed)
```