### PR TITLE
dynamic pipeline creation broken down into individual functions

### DIFF
--- a/ibllib/pipes/dynamic_pipeline.py
+++ b/ibllib/pipes/dynamic_pipeline.py
@@ -216,12 +216,7 @@ def _get_trials_tasks(session_path, acquisition_description=None, sync_tasks=Non
     kwargs = {'session_path': session_path, 'one': one}
 
     # Syncing tasks
-    ((sync, sync_args),) = acquisition_description['sync'].items()
-    sync_label = _sync_label(sync, **sync_args)  # get the format of the DAQ data. This informs the extractor task
-    sync_args['sync_collection'] = sync_args.pop('collection')  # rename the key so it matches task run arguments
-    sync_args['sync_ext'] = sync_args.pop('extension', None)
-    sync_args['sync_namespace'] = sync_args.pop('acquisition_software', None)
-    sync_kwargs = {'sync': sync, **sync_args}
+    _, sync_label, _, sync_kwargs = _get_sync_config(acquisition_description)
 
     # Behavior tasks
     protocol_numbers = set()

--- a/ibllib/pipes/dynamic_pipeline.py
+++ b/ibllib/pipes/dynamic_pipeline.py
@@ -362,6 +362,288 @@ def get_trials_tasks(session_path, one=None, bpod_only=False):
         return []
 
 
+def _get_sync_config(acquisition_description):
+    ((sync, sync_args),) = acquisition_description['sync'].items()
+    sync_args = sync_args.copy()  # ensure acquisition_description unchanged
+    sync_label = _sync_label(sync, **sync_args)  # get the format of the DAQ data. This informs the extractor task
+    sync_args['sync_collection'] = sync_args.pop('collection')  # rename the key so it matches task run arguments
+    sync_args['sync_ext'] = sync_args.pop('extension', None)
+    sync_args['sync_namespace'] = sync_args.pop('acquisition_software', None)
+    sync_kwargs = {'sync': sync, **sync_args}
+    return sync, sync_label, sync_args, sync_kwargs
+
+
+def get_sync_tasks(acquisition_description, sync_tasks, **kwargs):
+    sync, sync_label, sync_args, sync_kwargs = _get_sync_config(acquisition_description)
+    sync_tasks = OrderedDict()
+    if sync_label == 'nidq' and sync_args['sync_collection'] == 'raw_ephys_data':
+        sync_tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (etasks.EphysSyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
+        sync_tasks[f'SyncPulses_{sync}'] = type(f'SyncPulses_{sync}', (etasks.EphysSyncPulses,), {})(
+            **kwargs, **sync_kwargs, parents=[sync_tasks['SyncRegisterRaw']]
+        )
+        sync_tasks = [sync_tasks[f'SyncPulses_{sync}']]
+    elif sync_label == 'timeline':
+        sync_tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
+    elif sync_label == 'nidq':
+        sync_tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncMtscomp,), {})(**kwargs, **sync_kwargs)
+        sync_tasks[f'SyncPulses_{sync}'] = type(f'SyncPulses_{sync}', (stasks.SyncPulses,), {})(
+            **kwargs, **sync_kwargs, parents=[sync_tasks['SyncRegisterRaw']]
+        )
+        sync_tasks = [sync_tasks[f'SyncPulses_{sync}']]
+    elif sync_label == 'tdms':
+        sync_tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
+    elif sync_label == 'bpod':
+        pass  # ATM we don't have anything for this; it may not be needed in the future
+    return sync_tasks
+
+
+def get_ephys_tasks(acquisition_description, sync_tasks, **kwargs):
+    session_path = kwargs['session_path']
+    ephys_tasks = OrderedDict()
+    _, _, _, sync_kwargs = _get_sync_config(acquisition_description)
+    devices = acquisition_description.get('devices', {})
+    if 'neuropixel' in devices:
+        ephys_kwargs = {'device_collection': 'raw_ephys_data'}
+        ephys_tasks['EphysRegisterRaw'] = type('EphysRegisterRaw', (etasks.EphysRegisterRaw,), {})(**kwargs, **ephys_kwargs)
+
+        all_probes = []
+        register_tasks = []
+        for pname, probe_info in devices['neuropixel'].items():
+            # Glob to support collections such as _00a, _00b. This doesn't fix the issue of NP2.4
+            # extractions, however.
+            probe_collection = next(session_path.glob(probe_info['collection'] + '*'))
+            meta_file = spikeglx.glob_ephys_files(probe_collection, ext='meta')
+            meta_file = meta_file[0].get('ap')
+            nptype = spikeglx._get_neuropixel_version_from_meta(spikeglx.read_meta_data(meta_file))
+            nshanks = spikeglx._get_nshanks_from_meta(spikeglx.read_meta_data(meta_file))
+
+            if (nptype == 'NP2.1') or (nptype == 'NP2.4' and nshanks == 1):
+                ephys_tasks[f'EphyCompressNP21_{pname}'] = type(f'EphyCompressNP21_{pname}', (etasks.EphysCompressNP21,), {})(
+                    **kwargs, **ephys_kwargs, pname=pname
+                )
+                all_probes.append(pname)
+                register_tasks.append(ephys_tasks[f'EphyCompressNP21_{pname}'])
+            elif nptype == 'NP2.4' and nshanks > 1:
+                ephys_tasks[f'EphyCompressNP24_{pname}'] = type(f'EphyCompressNP24_{pname}', (etasks.EphysCompressNP24,), {})(
+                    **kwargs, **ephys_kwargs, pname=pname, nshanks=nshanks
+                )
+                register_tasks.append(ephys_tasks[f'EphyCompressNP24_{pname}'])
+                all_probes += [f'{pname}{chr(97 + int(shank))}' for shank in range(nshanks)]
+            else:
+                ephys_tasks[f'EphysCompressNP1_{pname}'] = type(f'EphyCompressNP1_{pname}', (etasks.EphysCompressNP1,), {})(
+                    **kwargs, **ephys_kwargs, pname=pname
+                )
+                register_tasks.append(ephys_tasks[f'EphysCompressNP1_{pname}'])
+                all_probes.append(pname)
+
+        if nptype == '3A':
+            ephys_tasks['EphysPulses'] = type('EphysPulses', (etasks.EphysPulses,), {})(
+                **kwargs, **ephys_kwargs, **sync_kwargs, pname=all_probes, parents=register_tasks + sync_tasks
+            )
+
+        for pname in all_probes:
+            register_task = [reg_task for reg_task in register_tasks if pname[:7] in reg_task.name]
+
+            if nptype != '3A':
+                ephys_tasks[f'EphysPulses_{pname}'] = type(f'EphysPulses_{pname}', (etasks.EphysPulses,), {})(
+                    **kwargs, **ephys_kwargs, **sync_kwargs, pname=[pname], parents=register_task + sync_tasks
+                )
+                ephys_tasks[f'Spikesorting_{pname}'] = type(f'Spikesorting_{pname}', (etasks.SpikeSorting,), {})(
+                    **kwargs, **ephys_kwargs, pname=pname, parents=[ephys_tasks[f'EphysPulses_{pname}']]
+                )
+            else:
+                ephys_tasks[f'Spikesorting_{pname}'] = type(f'Spikesorting_{pname}', (etasks.SpikeSorting,), {})(
+                    **kwargs, **ephys_kwargs, pname=pname, parents=[ephys_tasks['EphysPulses']]
+                )
+
+            ephys_tasks[f'RawEphysQC_{pname}'] = type(f'RawEphysQC_{pname}', (etasks.RawEphysQC,), {})(
+                **kwargs, **ephys_kwargs, pname=pname, parents=register_task
+            )
+
+    return ephys_tasks
+
+
+def get_video_tasks(acquisition_description, sync_tasks, **kwargs):
+    devices = acquisition_description.get('devices', {})
+    sync, _, _, sync_kwargs = _get_sync_config(acquisition_description)
+    video_tasks = OrderedDict()
+
+    if 'cameras' in devices:
+        cams = list(devices['cameras'].keys())
+        subset_cams = [c for c in cams if c in ('left', 'right', 'body', 'belly')]
+        video_kwargs = {'device_collection': 'raw_video_data', 'cameras': cams}
+        video_compressed = sess_params.get_video_compressed(acquisition_description)
+
+        if video_compressed:
+            # This is for widefield case where the video is already compressed
+            video_tasks[tn] = type((tn := 'VideoConvert'), (vtasks.VideoConvert,), {})(**kwargs, **video_kwargs)
+            dlc_parent_task = video_tasks['VideoConvert']
+            video_tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcCamlog,), {})(
+                **kwargs, **video_kwargs, **sync_kwargs
+            )
+        else:
+            video_tasks[tn] = type((tn := 'VideoRegisterRaw'), (vtasks.VideoRegisterRaw,), {})(**kwargs, **video_kwargs)
+            video_tasks[tn] = type((tn := 'VideoCompress'), (vtasks.VideoCompress,), {})(**kwargs, **video_kwargs, **sync_kwargs)
+            dlc_parent_task = video_tasks['VideoCompress']
+            if sync == 'bpod':
+                video_tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcBpod,), {})(
+                    **kwargs, **video_kwargs, **sync_kwargs, parents=[video_tasks['VideoCompress']]
+                )
+            elif sync == 'nidq':
+                # Here we restrict to videos that we support (left, right or body)
+                video_kwargs['cameras'] = subset_cams
+                video_tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcNidq,), {})(
+                    **kwargs, **video_kwargs, **sync_kwargs, parents=[video_tasks['VideoCompress']] + sync_tasks
+                )
+
+        if sync_kwargs['sync'] != 'bpod':
+            # Here we restrict to videos that we support (left, right or body)
+            # Currently there is no plan to run DLC on the belly cam
+            subset_cams = [c for c in cams if c in ('left', 'right', 'body')]
+            video_kwargs['cameras'] = subset_cams
+            video_tasks[tn] = type((tn := 'DLC'), (vtasks.DLC,), {})(**kwargs, **video_kwargs, parents=[dlc_parent_task])
+
+            # The PostDLC plots require a trials object for QC
+            # Find the first task that outputs a trials.table dataset
+            trials_task = (
+                t for t in video_tasks.values() if any('trials.table' in f[0] for f in t.signature.get('output_files', []))
+            )
+            if trials_task := next(trials_task, None):
+                parents = [video_tasks['DLC'], video_tasks[f'VideoSyncQC_{sync}'], trials_task]
+                trials_collection = getattr(trials_task, 'output_collection', 'alf')
+            else:
+                parents = [video_tasks['DLC'], video_tasks[f'VideoSyncQC_{sync}']]
+                trials_collection = 'alf'
+            video_tasks[tn] = type((tn := 'PostDLC'), (vtasks.EphysPostDLC,), {})(
+                **kwargs, cameras=subset_cams, trials_collection=trials_collection, parents=parents
+            )
+
+    return video_tasks
+
+
+def get_audio_tasks(acquisition_description, **kwargs):
+    _, _, _, sync_kwargs = _get_sync_config(acquisition_description)
+    devices = acquisition_description.get('devices', {})
+    audio_tasks = OrderedDict()
+    if 'microphone' in devices:
+        ((microphone, micro_kwargs),) = devices['microphone'].items()
+        micro_kwargs['device_collection'] = micro_kwargs.pop('collection')
+        if sync_kwargs['sync'] == 'bpod':
+            audio_tasks['AudioRegisterRaw'] = type('AudioRegisterRaw', (atasks.AudioSync,), {})(
+                **kwargs, **sync_kwargs, **micro_kwargs, collection=micro_kwargs['device_collection']
+            )
+        elif sync_kwargs['sync'] == 'nidq':
+            audio_tasks['AudioRegisterRaw'] = type('AudioRegisterRaw', (atasks.AudioCompress,), {})(**kwargs, **micro_kwargs)
+
+    return audio_tasks
+
+
+def get_wfield_tasks(acquisition_description, sync_tasks, **kwargs):
+    _, _, _, sync_kwargs = _get_sync_config(acquisition_description)
+    devices = acquisition_description.get('devices', {})
+    wfield_tasks = OrderedDict()
+
+    if 'widefield' in devices:
+        ((_, wfield_kwargs),) = devices['widefield'].items()
+        wfield_kwargs['device_collection'] = wfield_kwargs.pop('collection')
+        wfield_tasks['WideFieldRegisterRaw'] = type('WidefieldRegisterRaw', (wtasks.WidefieldRegisterRaw,), {})(
+            **kwargs, **wfield_kwargs
+        )
+        wfield_tasks['WidefieldCompress'] = type('WidefieldCompress', (wtasks.WidefieldCompress,), {})(
+            **kwargs, **wfield_kwargs, parents=[wfield_tasks['WideFieldRegisterRaw']]
+        )
+        wfield_tasks['WidefieldPreprocess'] = type('WidefieldPreprocess', (wtasks.WidefieldPreprocess,), {})(
+            **kwargs, **wfield_kwargs, parents=[wfield_tasks['WidefieldCompress']]
+        )
+        wfield_tasks['WidefieldSync'] = type('WidefieldSync', (wtasks.WidefieldSync,), {})(
+            **kwargs,
+            **wfield_kwargs,
+            **sync_kwargs,
+            parents=[wfield_tasks['WideFieldRegisterRaw'], wfield_tasks['WidefieldCompress']] + sync_tasks,
+        )
+        wfield_tasks['WidefieldFOV'] = type('WidefieldFOV', (wtasks.WidefieldFOV,), {})(
+            **kwargs, **wfield_kwargs, parents=[wfield_tasks['WidefieldPreprocess']]
+        )
+
+    return wfield_tasks
+
+
+def get_mesoscope_tasks(acquisition_description, **kwargs):
+    _, _, _, sync_kwargs = _get_sync_config(acquisition_description)
+    devices = acquisition_description.get('devices', {})
+
+    mesoscope_tasks = OrderedDict()
+    if 'mesoscope' in devices:
+        ((_, mscope_kwargs),) = devices['mesoscope'].items()
+        mscope_kwargs['device_collection'] = mscope_kwargs.pop('collection')
+        mesoscope_tasks['MesoscopeRegisterSnapshots'] = type(
+            'MesoscopeRegisterSnapshots', (mscope_tasks.MesoscopeRegisterSnapshots,), {}
+        )(**kwargs, **mscope_kwargs)
+        mesoscope_tasks['MesoscopePreprocess'] = type('MesoscopePreprocess', (mscope_tasks.MesoscopePreprocess,), {})(
+            **kwargs, **mscope_kwargs
+        )
+        mesoscope_tasks['MesoscopeFOV'] = type('MesoscopeFOV', (mscope_tasks.MesoscopeFOV,), {})(
+            **kwargs, **mscope_kwargs, parents=[mesoscope_tasks['MesoscopePreprocess']]
+        )
+        mesoscope_tasks['MesoscopeSync'] = type('MesoscopeSync', (mscope_tasks.MesoscopeSync,), {})(
+            **kwargs, **mscope_kwargs, **sync_kwargs
+        )
+        mesoscope_tasks['MesoscopeCompress'] = type('MesoscopeCompress', (mscope_tasks.MesoscopeCompress,), {})(
+            **kwargs, **mscope_kwargs, parents=[mesoscope_tasks['MesoscopePreprocess']]
+        )
+
+    return mesoscope_tasks
+
+
+def get_photometry_tasks(acquisition_description, **kwargs):
+    devices = acquisition_description.get('devices', {})
+    photometry_tasks = OrderedDict()
+
+    if 'neurophotometrics' in devices:
+        from iblphotometry.tasks import (
+            FibrePhotometryBpodSync,
+            FibrePhotometryDAQSync,
+            FibrePhotometryPassiveChoiceWorld,
+            # FibrePhotometryQC,
+        )
+
+        sync_mode = devices['neurophotometrics']['sync_mode']
+
+        # passive photometry
+        task_protocols = acquisition_description['tasks']
+        assert len(task_protocols) == 1, 'chained protocols are not yet supported for photometry extraction'
+        protocol = task_protocols[0]
+        if 'passive' in protocol:
+            photometry_tasks['FibrePhotometryPassiveChoiceWorld'] = type(
+                'FibrePhotometryPassiveChoiceWorld', (FibrePhotometryPassiveChoiceWorld,), {}
+            )(**kwargs)
+
+        # syncing / extraction
+        match sync_mode:
+            case 'bpod':
+                # for synchronization with the BNC inputs of the neurophotometrics receiving the sync pulses
+                # from the individual bpods
+                photometry_tasks['FibrePhotometryBpodSync'] = type('FibrePhotometryBpodSync', (FibrePhotometryBpodSync,), {})(
+                    **kwargs,
+                )
+            case 'daqami':
+                # for synchronization with the DAQami receiving the sync pulses from the individual bpods
+                # as well as the frame clock from the FP3002
+                if 'passive' not in protocol:  # excluding passive session
+                    photometry_tasks['FibrePhotometryDAQSync'] = type('FibrePhotometryDAQSync', (FibrePhotometryDAQSync,), {})(
+                        **kwargs,
+                    )
+            case _:
+                raise ValueError('unknown sync mode')
+
+        # QC
+        # tasks['FibrePhotometryQC'] = type('FibrePhotometryQC', (FibrePhotometryQC,), {})(
+        #     **kwargs, parents=[tasks['FibrePhotometryDAQSync']]  # conditional parents?
+        # )
+
+    return photometry_tasks
+
+
 def is_active_trials_task(task) -> bool:
     """
     Check if task is for active choice world extraction.
@@ -403,7 +685,6 @@ def make_pipeline(session_path, **pkwargs):
         raise ValueError('Session path does not exist')
     tasks = OrderedDict()
     acquisition_description = _load_acquisition_description(session_path)
-    devices = acquisition_description.get('devices', {})
     kwargs = {'session_path': session_path, 'one': pkwargs.get('one')}
 
     # Registers the experiment description file
@@ -412,240 +693,38 @@ def make_pipeline(session_path, **pkwargs):
     )(**kwargs)
 
     # Syncing tasks
-    ((sync, sync_args),) = acquisition_description['sync'].items()
-    sync_args = sync_args.copy()  # ensure acquisition_description unchanged
-    sync_label = _sync_label(sync, **sync_args)  # get the format of the DAQ data. This informs the extractor task
-    sync_args['sync_collection'] = sync_args.pop('collection')  # rename the key so it matches task run arguments
-    sync_args['sync_ext'] = sync_args.pop('extension', None)
-    sync_args['sync_namespace'] = sync_args.pop('acquisition_software', None)
-    sync_kwargs = {'sync': sync, **sync_args}
-    sync_tasks = []
-    if sync_label == 'nidq' and sync_args['sync_collection'] == 'raw_ephys_data':
-        tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (etasks.EphysSyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
-        tasks[f'SyncPulses_{sync}'] = type(f'SyncPulses_{sync}', (etasks.EphysSyncPulses,), {})(
-            **kwargs, **sync_kwargs, parents=[tasks['SyncRegisterRaw']]
-        )
-        sync_tasks = [tasks[f'SyncPulses_{sync}']]
-    elif sync_label == 'timeline':
-        tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
-    elif sync_label == 'nidq':
-        tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncMtscomp,), {})(**kwargs, **sync_kwargs)
-        tasks[f'SyncPulses_{sync}'] = type(f'SyncPulses_{sync}', (stasks.SyncPulses,), {})(
-            **kwargs, **sync_kwargs, parents=[tasks['SyncRegisterRaw']]
-        )
-        sync_tasks = [tasks[f'SyncPulses_{sync}']]
-    elif sync_label == 'tdms':
-        tasks['SyncRegisterRaw'] = type('SyncRegisterRaw', (stasks.SyncRegisterRaw,), {})(**kwargs, **sync_kwargs)
-    elif sync_label == 'bpod':
-        pass  # ATM we don't have anything for this; it may not be needed in the future
+    sync_tasks = get_sync_tasks(session_path, acquisition_description, **kwargs)
+    tasks.update(sync_tasks)
 
     # Behavior tasks
-    tasks.update(_get_trials_tasks(session_path, acquisition_description, sync_tasks=sync_tasks, one=pkwargs.get('one')))
+    behavior_tasks = _get_trials_tasks(session_path, acquisition_description, sync_tasks=sync_tasks, one=pkwargs.get('one'))
+    tasks.update(behavior_tasks)
 
     # Ephys tasks
-    if 'neuropixel' in devices:
-        ephys_kwargs = {'device_collection': 'raw_ephys_data'}
-        tasks['EphysRegisterRaw'] = type('EphysRegisterRaw', (etasks.EphysRegisterRaw,), {})(**kwargs, **ephys_kwargs)
-
-        all_probes = []
-        register_tasks = []
-        for pname, probe_info in devices['neuropixel'].items():
-            # Glob to support collections such as _00a, _00b. This doesn't fix the issue of NP2.4
-            # extractions, however.
-            probe_collection = next(session_path.glob(probe_info['collection'] + '*'))
-            meta_file = spikeglx.glob_ephys_files(probe_collection, ext='meta')
-            meta_file = meta_file[0].get('ap')
-            nptype = spikeglx._get_neuropixel_version_from_meta(spikeglx.read_meta_data(meta_file))
-            nshanks = spikeglx._get_nshanks_from_meta(spikeglx.read_meta_data(meta_file))
-
-            if (nptype == 'NP2.1') or (nptype == 'NP2.4' and nshanks == 1):
-                tasks[f'EphyCompressNP21_{pname}'] = type(f'EphyCompressNP21_{pname}', (etasks.EphysCompressNP21,), {})(
-                    **kwargs, **ephys_kwargs, pname=pname
-                )
-                all_probes.append(pname)
-                register_tasks.append(tasks[f'EphyCompressNP21_{pname}'])
-            elif nptype == 'NP2.4' and nshanks > 1:
-                tasks[f'EphyCompressNP24_{pname}'] = type(f'EphyCompressNP24_{pname}', (etasks.EphysCompressNP24,), {})(
-                    **kwargs, **ephys_kwargs, pname=pname, nshanks=nshanks
-                )
-                register_tasks.append(tasks[f'EphyCompressNP24_{pname}'])
-                all_probes += [f'{pname}{chr(97 + int(shank))}' for shank in range(nshanks)]
-            else:
-                tasks[f'EphysCompressNP1_{pname}'] = type(f'EphyCompressNP1_{pname}', (etasks.EphysCompressNP1,), {})(
-                    **kwargs, **ephys_kwargs, pname=pname
-                )
-                register_tasks.append(tasks[f'EphysCompressNP1_{pname}'])
-                all_probes.append(pname)
-
-        if nptype == '3A':
-            tasks['EphysPulses'] = type('EphysPulses', (etasks.EphysPulses,), {})(
-                **kwargs, **ephys_kwargs, **sync_kwargs, pname=all_probes, parents=register_tasks + sync_tasks
-            )
-
-        for pname in all_probes:
-            register_task = [reg_task for reg_task in register_tasks if pname[:7] in reg_task.name]
-
-            if nptype != '3A':
-                tasks[f'EphysPulses_{pname}'] = type(f'EphysPulses_{pname}', (etasks.EphysPulses,), {})(
-                    **kwargs, **ephys_kwargs, **sync_kwargs, pname=[pname], parents=register_task + sync_tasks
-                )
-                tasks[f'Spikesorting_{pname}'] = type(f'Spikesorting_{pname}', (etasks.SpikeSorting,), {})(
-                    **kwargs, **ephys_kwargs, pname=pname, parents=[tasks[f'EphysPulses_{pname}']]
-                )
-            else:
-                tasks[f'Spikesorting_{pname}'] = type(f'Spikesorting_{pname}', (etasks.SpikeSorting,), {})(
-                    **kwargs, **ephys_kwargs, pname=pname, parents=[tasks['EphysPulses']]
-                )
-
-            tasks[f'RawEphysQC_{pname}'] = type(f'RawEphysQC_{pname}', (etasks.RawEphysQC,), {})(
-                **kwargs, **ephys_kwargs, pname=pname, parents=register_task
-            )
+    ephys_tasks = get_ephys_tasks()
+    tasks.update(ephys_tasks)
 
     # Video tasks
-    if 'cameras' in devices:
-        cams = list(devices['cameras'].keys())
-        subset_cams = [c for c in cams if c in ('left', 'right', 'body', 'belly')]
-        video_kwargs = {'device_collection': 'raw_video_data', 'cameras': cams}
-        video_compressed = sess_params.get_video_compressed(acquisition_description)
-
-        if video_compressed:
-            # This is for widefield case where the video is already compressed
-            tasks[tn] = type((tn := 'VideoConvert'), (vtasks.VideoConvert,), {})(**kwargs, **video_kwargs)
-            dlc_parent_task = tasks['VideoConvert']
-            tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcCamlog,), {})(
-                **kwargs, **video_kwargs, **sync_kwargs
-            )
-        else:
-            tasks[tn] = type((tn := 'VideoRegisterRaw'), (vtasks.VideoRegisterRaw,), {})(**kwargs, **video_kwargs)
-            tasks[tn] = type((tn := 'VideoCompress'), (vtasks.VideoCompress,), {})(**kwargs, **video_kwargs, **sync_kwargs)
-            dlc_parent_task = tasks['VideoCompress']
-            if sync == 'bpod':
-                tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcBpod,), {})(
-                    **kwargs, **video_kwargs, **sync_kwargs, parents=[tasks['VideoCompress']]
-                )
-            elif sync == 'nidq':
-                # Here we restrict to videos that we support (left, right or body)
-                video_kwargs['cameras'] = subset_cams
-                tasks[tn] = type((tn := f'VideoSyncQC_{sync}'), (vtasks.VideoSyncQcNidq,), {})(
-                    **kwargs, **video_kwargs, **sync_kwargs, parents=[tasks['VideoCompress']] + sync_tasks
-                )
-
-        if sync_kwargs['sync'] != 'bpod':
-            # Here we restrict to videos that we support (left, right or body)
-            # Currently there is no plan to run DLC on the belly cam
-            subset_cams = [c for c in cams if c in ('left', 'right', 'body')]
-            video_kwargs['cameras'] = subset_cams
-            tasks[tn] = type((tn := 'DLC'), (vtasks.DLC,), {})(**kwargs, **video_kwargs, parents=[dlc_parent_task])
-
-            # The PostDLC plots require a trials object for QC
-            # Find the first task that outputs a trials.table dataset
-            trials_task = (t for t in tasks.values() if any('trials.table' in f[0] for f in t.signature.get('output_files', [])))
-            if trials_task := next(trials_task, None):
-                parents = [tasks['DLC'], tasks[f'VideoSyncQC_{sync}'], trials_task]
-                trials_collection = getattr(trials_task, 'output_collection', 'alf')
-            else:
-                parents = [tasks['DLC'], tasks[f'VideoSyncQC_{sync}']]
-                trials_collection = 'alf'
-            tasks[tn] = type((tn := 'PostDLC'), (vtasks.EphysPostDLC,), {})(
-                **kwargs, cameras=subset_cams, trials_collection=trials_collection, parents=parents
-            )
+    video_tasks = get_video_tasks()
+    tasks.update(video_tasks)
 
     # Audio tasks
-    if 'microphone' in devices:
-        ((microphone, micro_kwargs),) = devices['microphone'].items()
-        micro_kwargs['device_collection'] = micro_kwargs.pop('collection')
-        if sync_kwargs['sync'] == 'bpod':
-            tasks['AudioRegisterRaw'] = type('AudioRegisterRaw', (atasks.AudioSync,), {})(
-                **kwargs, **sync_kwargs, **micro_kwargs, collection=micro_kwargs['device_collection']
-            )
-        elif sync_kwargs['sync'] == 'nidq':
-            tasks['AudioRegisterRaw'] = type('AudioRegisterRaw', (atasks.AudioCompress,), {})(**kwargs, **micro_kwargs)
+    audio_tasks = get_audio_tasks()
+    tasks.update(audio_tasks)
 
     # Widefield tasks
-    if 'widefield' in devices:
-        ((_, wfield_kwargs),) = devices['widefield'].items()
-        wfield_kwargs['device_collection'] = wfield_kwargs.pop('collection')
-        tasks['WideFieldRegisterRaw'] = type('WidefieldRegisterRaw', (wtasks.WidefieldRegisterRaw,), {})(
-            **kwargs, **wfield_kwargs
-        )
-        tasks['WidefieldCompress'] = type('WidefieldCompress', (wtasks.WidefieldCompress,), {})(
-            **kwargs, **wfield_kwargs, parents=[tasks['WideFieldRegisterRaw']]
-        )
-        tasks['WidefieldPreprocess'] = type('WidefieldPreprocess', (wtasks.WidefieldPreprocess,), {})(
-            **kwargs, **wfield_kwargs, parents=[tasks['WidefieldCompress']]
-        )
-        tasks['WidefieldSync'] = type('WidefieldSync', (wtasks.WidefieldSync,), {})(
-            **kwargs,
-            **wfield_kwargs,
-            **sync_kwargs,
-            parents=[tasks['WideFieldRegisterRaw'], tasks['WidefieldCompress']] + sync_tasks,
-        )
-        tasks['WidefieldFOV'] = type('WidefieldFOV', (wtasks.WidefieldFOV,), {})(
-            **kwargs, **wfield_kwargs, parents=[tasks['WidefieldPreprocess']]
-        )
+    wfield_tasks = get_wfield_tasks()
+    tasks.update(wfield_tasks)
 
     # Mesoscope tasks
-    if 'mesoscope' in devices:
-        ((_, mscope_kwargs),) = devices['mesoscope'].items()
-        mscope_kwargs['device_collection'] = mscope_kwargs.pop('collection')
-        tasks['MesoscopeRegisterSnapshots'] = type('MesoscopeRegisterSnapshots', (mscope_tasks.MesoscopeRegisterSnapshots,), {})(
-            **kwargs, **mscope_kwargs
-        )
-        tasks['MesoscopePreprocess'] = type('MesoscopePreprocess', (mscope_tasks.MesoscopePreprocess,), {})(
-            **kwargs, **mscope_kwargs
-        )
-        tasks['MesoscopeFOV'] = type('MesoscopeFOV', (mscope_tasks.MesoscopeFOV,), {})(
-            **kwargs, **mscope_kwargs, parents=[tasks['MesoscopePreprocess']]
-        )
-        tasks['MesoscopeSync'] = type('MesoscopeSync', (mscope_tasks.MesoscopeSync,), {})(
-            **kwargs, **mscope_kwargs, **sync_kwargs
-        )
-        tasks['MesoscopeCompress'] = type('MesoscopeCompress', (mscope_tasks.MesoscopeCompress,), {})(
-            **kwargs, **mscope_kwargs, parents=[tasks['MesoscopePreprocess']]
-        )
+    mesoscope_tasks = get_mesoscope_tasks()
+    tasks.update(mesoscope_tasks)
 
-    if 'neurophotometrics' in devices:
-        from iblphotometry.tasks import (
-            FibrePhotometryBpodSync,
-            FibrePhotometryDAQSync,
-            FibrePhotometryPassiveChoiceWorld,
-            # FibrePhotometryQC,
-        )
+    # photometry tasks
+    photometry_tasks = get_photometry_tasks()
+    tasks.update(photometry_tasks)
 
-        sync_mode = devices['neurophotometrics']['sync_mode']
-
-        # passive photometry
-        task_protocols = acquisition_description['tasks']
-        assert len(task_protocols) == 1, 'chained protocols are not yet supported for photometry extraction'
-        protocol = task_protocols[0]
-        if 'passive' in protocol:
-            tasks['FibrePhotometryPassiveChoiceWorld'] = type(
-                'FibrePhotometryPassiveChoiceWorld', (FibrePhotometryPassiveChoiceWorld,), {}
-            )(**kwargs)
-
-        # syncing / extraction
-        match sync_mode:
-            case 'bpod':
-                # for synchronization with the BNC inputs of the neurophotometrics receiving the sync pulses
-                # from the individual bpods
-                tasks['FibrePhotometryBpodSync'] = type('FibrePhotometryBpodSync', (FibrePhotometryBpodSync,), {})(
-                    **kwargs,
-                )
-            case 'daqami':
-                # for synchronization with the DAQami receiving the sync pulses from the individual bpods
-                # as well as the frame clock from the FP3002
-                if 'passive' not in protocol:  # excluding passive session
-                    tasks['FibrePhotometryDAQSync'] = type('FibrePhotometryDAQSync', (FibrePhotometryDAQSync,), {})(
-                        **kwargs,
-                    )
-            case _:
-                raise ValueError('unknown sync mode')
-
-        # QC
-        # tasks['FibrePhotometryQC'] = type('FibrePhotometryQC', (FibrePhotometryQC,), {})(
-        #     **kwargs, parents=[tasks['FibrePhotometryDAQSync']]  # conditional parents?
-        # )
-
+    # combine: make pipeline and add tasks
     p = mtasks.Pipeline(session_path=session_path, **pkwargs)
     p.tasks = tasks
     return p

--- a/ibllib/pipes/dynamic_pipeline.py
+++ b/ibllib/pipes/dynamic_pipeline.py
@@ -373,7 +373,7 @@ def _get_sync_config(acquisition_description):
     return sync, sync_label, sync_args, sync_kwargs
 
 
-def get_sync_tasks(acquisition_description, sync_tasks, **kwargs):
+def get_sync_tasks(acquisition_description, **kwargs):
     sync, sync_label, sync_args, sync_kwargs = _get_sync_config(acquisition_description)
     sync_tasks = OrderedDict()
     if sync_label == 'nidq' and sync_args['sync_collection'] == 'raw_ephys_data':
@@ -693,7 +693,7 @@ def make_pipeline(session_path, **pkwargs):
     )(**kwargs)
 
     # Syncing tasks
-    sync_tasks = get_sync_tasks(session_path, acquisition_description, **kwargs)
+    sync_tasks = get_sync_tasks(acquisition_description, **kwargs)
     tasks.update(sync_tasks)
 
     # Behavior tasks
@@ -701,27 +701,27 @@ def make_pipeline(session_path, **pkwargs):
     tasks.update(behavior_tasks)
 
     # Ephys tasks
-    ephys_tasks = get_ephys_tasks()
+    ephys_tasks = get_ephys_tasks(acquisition_description, sync_tasks, **kwargs)
     tasks.update(ephys_tasks)
 
     # Video tasks
-    video_tasks = get_video_tasks()
+    video_tasks = get_video_tasks(acquisition_description, sync_tasks, **kwargs)
     tasks.update(video_tasks)
 
     # Audio tasks
-    audio_tasks = get_audio_tasks()
+    audio_tasks = get_audio_tasks(acquisition_description, **kwargs)
     tasks.update(audio_tasks)
 
     # Widefield tasks
-    wfield_tasks = get_wfield_tasks()
+    wfield_tasks = get_wfield_tasks(acquisition_description, sync_tasks, **kwargs)
     tasks.update(wfield_tasks)
 
     # Mesoscope tasks
-    mesoscope_tasks = get_mesoscope_tasks()
+    mesoscope_tasks = get_mesoscope_tasks(acquisition_description, **kwargs)
     tasks.update(mesoscope_tasks)
 
     # photometry tasks
-    photometry_tasks = get_photometry_tasks()
+    photometry_tasks = get_photometry_tasks(acquisition_description, **kwargs)
     tasks.update(photometry_tasks)
 
     # combine: make pipeline and add tasks

--- a/ibllib/pipes/dynamic_pipeline.py
+++ b/ibllib/pipes/dynamic_pipeline.py
@@ -716,8 +716,8 @@ def make_pipeline(session_path, **pkwargs):
     tasks.update(mesoscope_tasks)
 
     # photometry tasks
-    photometry_tasks = get_photometry_tasks(acquisition_description, **kwargs)
-    tasks.update(photometry_tasks)
+    # photometry_tasks = get_photometry_tasks(acquisition_description, **kwargs)
+    # tasks.update(photometry_tasks)
 
     # combine: make pipeline and add tasks
     p = mtasks.Pipeline(session_path=session_path, **pkwargs)


### PR DESCRIPTION
moved the individual parts of the dynamic pipeline creation into separate functions, as it was already the case for behavior tasks. No functionality added or removed, just refactoring

these changes are made to be able to only use part of the dynamic pipeline creation, for example from nextflow

