### PR TITLE
Fix held tasks not released after long-running parent completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.1] 2026-05-22
+
+### Fixed
+- Re-fetch job deck from Alyx after task completion so Held children are correctly released to Waiting even when set by concurrent workers during a long-running parent task
+
 ## [4.0.0] 2026-04-15
 
 ## Removed

--- a/ibllib/__init__.py
+++ b/ibllib/__init__.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 import os
 
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 warnings.filterwarnings('always', category=DeprecationWarning, module='ibllib')
 
 # if this becomes a full-blown library we should let the logging configuration to the discretion of the dev

--- a/ibllib/pipes/tasks.py
+++ b/ibllib/pipes/tasks.py
@@ -991,13 +991,15 @@ def run_alyx_task(
     # update task status on Alyx
     t = one.alyx.rest('tasks', 'partial_update', id=tdict['id'], data=patch_data)
     # check for dependent held tasks
-    # NB: Assumes dependent tasks are all part of the same session!
+    # Re-fetch the deck so children set to Held while this task was running (race condition for
+    # long tasks with concurrent workers) are visible to the transition check.
     next(x for x in job_deck if x['id'] == t['id'])['status'] = t['status']  # Update status in job deck
-    dependent_tasks = filter(lambda x: t['id'] in x['parents'] and x['status'] == 'Held', job_deck)
+    current_deck = one.alyx.rest('tasks', 'list', session=tdict['session'], no_cache=True)
+    dependent_tasks = filter(lambda x: t['id'] in x['parents'] and x['status'] == 'Held', current_deck)
     for d in dependent_tasks:
         assert d['id'] != t['id'], 'task its own parent'
         # if all their parent tasks now complete, set to waiting
-        parent_status = [next(x['status'] for x in job_deck if x['id'] == y) for y in d['parents']]
+        parent_status = [next(x['status'] for x in current_deck if x['id'] == y) for y in d['parents']]
         if set(parent_status) <= {'Complete', 'Incomplete'}:
             one.alyx.rest('tasks', 'partial_update', id=d['id'], data={'status': 'Waiting'})
     task.cleanUp()


### PR DESCRIPTION
## Summary

- `run_alyx_task` fetched `job_deck` once at task start (line 892) and reused the same snapshot after completion to find Held children to release to Waiting
- Concurrent workers that set children to Held *during* a long-running parent task were invisible to the stale snapshot, leaving those children permanently stuck in Held state
- Fix: re-fetch the deck from Alyx immediately after the parent task completes, so the Held→Waiting transition sees current task states

## Reproducer

Observed on session `SWC_NM_113/2026-05-14/001`: `EphyCompressNP1_probe01` ran for 44 minutes. Two concurrent workers set `EphysPulses_probe01` and `RawEphysQC_probe01` to Held at 18:56–18:57 (parents not yet complete). When EphysCompress finished at 19:41, its stale 18:55 snapshot showed those tasks as Waiting — the `status == 'Held'` filter matched nothing and no transition fired. `probe00` worked correctly because its compress ran hours later, by which time its child tasks were already Held in any freshly-fetched deck.