### PR TITLE
Feature/tidy trials table loader

### DIFF
--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -5,7 +5,6 @@ import gc
 import logging
 import re
 import copy
-import math
 from pathlib import Path
 from collections import defaultdict
 from typing import Literal
@@ -1425,7 +1424,7 @@ class SessionLoader:
         self.one.wildcards = True
         self.data_info.loc[self.data_info['name'] == 'trials', 'is_loaded'] = True
         if style == 'tidy':
-            self.trials = self._apply_tidy_transformations(self.trials)
+            self.trials = self.apply_tidy_transformations(self.trials)
 
     def load_wheel(self, fs=1000, corner_frequency=20, order=8, collection=None):
         """
@@ -1671,41 +1670,26 @@ class SessionLoader:
         #   - Left 25% trial: contrastLeft=0.25, contrastRight=NaN
         #   - Right 0% trial: contrastLeft=NaN, contrastRight=0.0
         #
-        # We consolidate into two tidy columns: gabor_stimulus_contrast and gabor_stimulus_side
-        def compute_gabor_stimulus_side(left, right):
-            # Determine side based on which column has a non-NaN value
-            left_valid = not pd.isna(left)
-            right_valid = not pd.isna(right)
-            if left_valid and not right_valid:
-                return 'left'
-            elif right_valid and not left_valid:
-                return 'right'
-            elif left_valid and right_valid:
-                # Both have values - should not happen in valid IBL data, but handle defensively
-                return 'left' if left >= right else 'right'
-            else:
-                return 'none'  # Both NaN - unexpected, indicates corrupted data
-
-        def compute_gabor_stimulus_contrast(left, right):
-            # Return the non-NaN contrast value as percentage (could be 0 for 0% contrast trials)
-            # Multiply by 100 and round to 2 decimal places
-            if not pd.isna(left) and (pd.isna(right) or left > 0):
-                return round(left * 100, 2)
-            elif not pd.isna(right):
-                return round(right * 100, 2)
-            else:
-                return np.nan  # Both NaN - unexpected
-
-        trials['gabor_stimulus_side'] = [
-            compute_gabor_stimulus_side(left, r) for left, r in zip(trials['contrastLeft'], trials['contrastRight'])
-        ]
-        trials['gabor_stimulus_contrast'] = [
-            compute_gabor_stimulus_contrast(left, r) for left, r in zip(trials['contrastLeft'], trials['contrastRight'])
-        ]
+        # We consolidate into two tidy columns: gabor_stimulus_side and gabor_stimulus_contrast.
+        # The side is given by which column is populated; the contrast by the populated value.
+        left = trials['contrastLeft']
+        right = trials['contrastRight']
+        left_valid = left.notna().to_numpy()
+        right_valid = right.notna().to_numpy()
+        trials['gabor_stimulus_side'] = np.select([left_valid, right_valid], ['left', 'right'], default='none')
+        # defensive: both columns populated should not happen in valid IBL data; if it does,
+        # attribute the trial to the side carrying the larger contrast
+        both_valid = left_valid & right_valid
+        if both_valid.any():
+            trials.loc[both_valid, 'gabor_stimulus_side'] = np.where(
+                left.to_numpy()[both_valid] >= right.to_numpy()[both_valid], 'left', 'right'
+            )
+        # take the non-NaN value (NaN where both are NaN) and express as a percentage
+        trials['gabor_stimulus_contrast'] = (left.fillna(right).to_numpy() * 100).round(2)
 
         # Compute block_index and block_type from probabilityLeft
         # Validate: probabilityLeft must not contain NaN (indicates corrupted trial data)
-        prob_left = trials['probabilityLeft'].values
+        prob_left = trials['probabilityLeft'].to_numpy()
         nan_mask = pd.isna(prob_left)
         if np.any(nan_mask):
             nan_indices = np.where(nan_mask)[0].tolist()
@@ -1714,27 +1698,23 @@ class SessionLoader:
                 'This indicates corrupted or incomplete trial data.'
             )
 
-        # block_index increments each time probabilityLeft changes
+        # block_index increments each time probabilityLeft changes (cumulative count of changes)
         block_index = np.zeros(len(prob_left), dtype=int)
-        current_block = 0
-        for i in range(1, len(prob_left)):
-            if not math.isclose(prob_left[i], prob_left[i - 1]):
-                current_block += 1
-            block_index[i] = current_block
+        if len(prob_left) > 1:
+            block_index[1:] = np.cumsum(~np.isclose(prob_left[1:], prob_left[:-1]))
         trials['block_index'] = block_index
 
-        # block_type: categorical based on probabilityLeft value
-        def compute_block_type(prob):
-            if math.isclose(prob, 0.5):
-                return 'unbiased'
-            elif math.isclose(prob, 0.8):
-                return 'left_block'
-            elif math.isclose(prob, 0.2):
-                return 'right_block'
-            else:
-                return f'p={prob}'  # Unexpected value, preserve it
-
-        trials['block_type'] = trials['probabilityLeft'].apply(compute_block_type)
+        # block_type: categorical label per known probabilityLeft value
+        block_type = np.select(
+            [np.isclose(prob_left, 0.5), np.isclose(prob_left, 0.8), np.isclose(prob_left, 0.2)],
+            ['unbiased', 'left_block', 'right_block'],
+            default='',
+        ).astype(object)
+        # preserve any unexpected probability values verbatim
+        unexpected = block_type == ''
+        if unexpected.any():
+            block_type[unexpected] = [f'p={prob}' for prob in prob_left[unexpected]]
+        trials['block_type'] = block_type
 
         return trials
 

--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -5,8 +5,10 @@ import gc
 import logging
 import re
 import copy
+import math
 from pathlib import Path
 from collections import defaultdict
+from typing import Literal
 
 import numpy as np
 import pandas as pd
@@ -1398,7 +1400,12 @@ class SessionLoader:
                 )
                 raise ALFMultipleCollectionsFound
 
-    def load_trials(self, collection=None, revision=None):
+    def load_trials(
+        self,
+        collection=None,
+        revision=None,
+        style: Literal['one', 'tidy'] = 'one',
+    ):
         """
         Function to load trials data into SessionLoader.trials
 
@@ -1417,6 +1424,8 @@ class SessionLoader:
         ).to_df()
         self.one.wildcards = True
         self.data_info.loc[self.data_info['name'] == 'trials', 'is_loaded'] = True
+        if style == 'tidy':
+            self.trials = self._apply_tidy_transformations(self.trials)
 
     def load_wheel(self, fs=1000, corner_frequency=20, order=8, collection=None):
         """
@@ -1532,8 +1541,8 @@ class SessionLoader:
         self.pawstates = {}
         for view in views:
             pawstates_raw = self.one.load_object(
-                self.eid, f'{view}Camera', attribute='pawstates', collection='alf/lightningaction',
-                revision=self.revision or None)
+                self.eid, f'{view}Camera', attribute='pawstates', collection='alf/lightningaction', revision=self.revision or None
+            )
             times_raw = self.one.load_object(
                 self.eid, f'{view}Camera', attribute='times', collection='alf',
                 revision=self.revision or None)
@@ -1614,6 +1623,120 @@ class SessionLoader:
             return video_timestamps_fixed, video_data
         else:
             return video_timestamps, video_data
+
+    @staticmethod
+    def _apply_tidy_transformations(trials: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply tidy data transformations to trials DataFrame.
+
+        Transformations:
+        - choice: -1/0/+1 -> "counter_clockwise"/"none"/"clockwise"
+        - feedbackType: -1/+1 -> True/False (is_mouse_rewarded)
+        - contrastLeft/contrastRight -> gabor_stimulus_contrast + gabor_stimulus_side
+        - probabilityLeft -> block_index (increments on change) + block_type (categorical)
+
+        Parameters
+        ----------
+        trials : pd.DataFrame
+            Raw trials data from SessionLoader.
+
+        Returns
+        -------
+        pd.DataFrame
+            Transformed trials with tidy column formats.
+        """
+        trials = trials.copy()
+
+        # Transform choice: -1 -> "counter_clockwise", 0 -> "none", +1 -> "clockwise"
+        choice_map = {-1.0: 'counter_clockwise', 0.0: 'none', 1.0: 'clockwise'}
+        trials['choice'] = trials['choice'].map(choice_map)
+
+        # Transform feedbackType to boolean: +1 -> True (rewarded), -1 -> False (not rewarded)
+        trials['is_mouse_rewarded'] = trials['feedbackType'] == 1.0
+
+        # Consolidate contrast columns into gabor_stimulus_contrast + gabor_stimulus_side
+        #
+        # IBL encodes stimulus side using contrastLeft/contrastRight columns where one column
+        # contains the contrast value and the other is NaN. This comes from the IBL extraction
+        # pipeline (ibllib/io/extractors/biased_trials.py ContrastLR extractor):
+        #
+        #   contrastLeft = [t['contrast'] if np.sign(t['position']) < 0 else np.nan ...]
+        #   contrastRight = [t['contrast'] if np.sign(t['position']) > 0 else np.nan ...]
+        #
+        # The stimulus position determines which column gets the value:
+        #   - position < 0 (left, -35 deg): contrastLeft = contrast, contrastRight = NaN
+        #   - position > 0 (right, +35 deg): contrastRight = contrast, contrastLeft = NaN
+        #
+        # This applies to ALL contrast levels including 0% contrast trials. For example:
+        #   - Left 25% trial: contrastLeft=0.25, contrastRight=NaN
+        #   - Right 0% trial: contrastLeft=NaN, contrastRight=0.0
+        #
+        # We consolidate into two tidy columns: gabor_stimulus_contrast and gabor_stimulus_side
+        def compute_gabor_stimulus_side(left, right):
+            # Determine side based on which column has a non-NaN value
+            left_valid = not pd.isna(left)
+            right_valid = not pd.isna(right)
+            if left_valid and not right_valid:
+                return 'left'
+            elif right_valid and not left_valid:
+                return 'right'
+            elif left_valid and right_valid:
+                # Both have values - should not happen in valid IBL data, but handle defensively
+                return 'left' if left >= right else 'right'
+            else:
+                return 'none'  # Both NaN - unexpected, indicates corrupted data
+
+        def compute_gabor_stimulus_contrast(left, right):
+            # Return the non-NaN contrast value as percentage (could be 0 for 0% contrast trials)
+            # Multiply by 100 and round to 2 decimal places
+            if not pd.isna(left) and (pd.isna(right) or left > 0):
+                return round(left * 100, 2)
+            elif not pd.isna(right):
+                return round(right * 100, 2)
+            else:
+                return np.nan  # Both NaN - unexpected
+
+        trials['gabor_stimulus_side'] = [
+            compute_gabor_stimulus_side(left, r) for left, r in zip(trials['contrastLeft'], trials['contrastRight'])
+        ]
+        trials['gabor_stimulus_contrast'] = [
+            compute_gabor_stimulus_contrast(left, r) for left, r in zip(trials['contrastLeft'], trials['contrastRight'])
+        ]
+
+        # Compute block_index and block_type from probabilityLeft
+        # Validate: probabilityLeft must not contain NaN (indicates corrupted trial data)
+        prob_left = trials['probabilityLeft'].values
+        nan_mask = pd.isna(prob_left)
+        if np.any(nan_mask):
+            nan_indices = np.where(nan_mask)[0].tolist()
+            raise ValueError(
+                f'probabilityLeft contains NaN values at trial indices {nan_indices}. '
+                'This indicates corrupted or incomplete trial data.'
+            )
+
+        # block_index increments each time probabilityLeft changes
+        block_index = np.zeros(len(prob_left), dtype=int)
+        current_block = 0
+        for i in range(1, len(prob_left)):
+            if not math.isclose(prob_left[i], prob_left[i - 1]):
+                current_block += 1
+            block_index[i] = current_block
+        trials['block_index'] = block_index
+
+        # block_type: categorical based on probabilityLeft value
+        def compute_block_type(prob):
+            if math.isclose(prob, 0.5):
+                return 'unbiased'
+            elif math.isclose(prob, 0.8):
+                return 'left_block'
+            elif math.isclose(prob, 0.2):
+                return 'right_block'
+            else:
+                return f'p={prob}'  # Unexpected value, preserve it
+
+        trials['block_type'] = trials['probabilityLeft'].apply(compute_block_type)
+
+        return trials
 
 
 class EphysSessionLoader(SessionLoader):

--- a/brainbox/io/one.py
+++ b/brainbox/io/one.py
@@ -1625,7 +1625,7 @@ class SessionLoader:
             return video_timestamps, video_data
 
     @staticmethod
-    def _apply_tidy_transformations(trials: pd.DataFrame) -> pd.DataFrame:
+    def apply_tidy_transformations(trials: pd.DataFrame) -> pd.DataFrame:
         """
         Apply tidy data transformations to trials DataFrame.
 

--- a/brainbox/tests/test_io.py
+++ b/brainbox/tests/test_io.py
@@ -1,12 +1,68 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 
 from brainbox.io import one as bbone
 
 
 class TestIO_ONE(unittest.TestCase):
     """Tests for brainbox.io.one functions that don't require fixtures on disk."""
+
+    @staticmethod
+    def _make_tidy_trials():
+        """Build a small trials DataFrame spanning several probabilityLeft blocks."""
+        return pd.DataFrame(
+            {
+                'choice': [-1.0, 0.0, 1.0, -1.0, 1.0, 0.0],
+                'feedbackType': [1.0, -1.0, 1.0, 1.0, -1.0, 1.0],
+                # one of contrastLeft/contrastRight holds the value, the other is NaN
+                'contrastLeft': [0.25, np.nan, 0.0, np.nan, 0.125, np.nan],
+                'contrastRight': [np.nan, 1.0, np.nan, 0.0, np.nan, 0.0625],
+                'probabilityLeft': [0.5, 0.5, 0.8, 0.8, 0.2, 0.5],
+            }
+        )
+
+    def test_tidy_choice_mapping(self):
+        """choice: -1/0/+1 map to counter_clockwise/none/clockwise."""
+        result = bbone.SessionLoader.apply_tidy_transformations(self._make_tidy_trials())
+        expected = ['counter_clockwise', 'none', 'clockwise', 'counter_clockwise', 'clockwise', 'none']
+        self.assertEqual(result['choice'].tolist(), expected)
+
+    def test_tidy_feedback_to_boolean(self):
+        """feedbackType +1/-1 maps to is_mouse_rewarded True/False."""
+        result = bbone.SessionLoader.apply_tidy_transformations(self._make_tidy_trials())
+        self.assertEqual(result['is_mouse_rewarded'].tolist(), [True, False, True, True, False, True])
+
+    def test_tidy_gabor_stimulus_side_and_contrast(self):
+        """contrastLeft/contrastRight consolidate into side + contrast (percent), including 0% trials."""
+        result = bbone.SessionLoader.apply_tidy_transformations(self._make_tidy_trials())
+        self.assertEqual(result['gabor_stimulus_side'].tolist(), ['left', 'right', 'left', 'right', 'left', 'right'])
+        np.testing.assert_array_almost_equal(
+            result['gabor_stimulus_contrast'].to_numpy(dtype=float), [25.0, 100.0, 0.0, 0.0, 12.5, 6.25]
+        )
+
+    def test_tidy_block_index_and_type(self):
+        """probabilityLeft yields an incrementing block_index and a categorical block_type."""
+        result = bbone.SessionLoader.apply_tidy_transformations(self._make_tidy_trials())
+        self.assertEqual(result['block_index'].tolist(), [0, 0, 1, 1, 2, 3])
+        self.assertEqual(
+            result['block_type'].tolist(),
+            ['unbiased', 'unbiased', 'left_block', 'left_block', 'right_block', 'unbiased'],
+        )
+
+    def test_tidy_does_not_mutate_input(self):
+        """The input DataFrame is copied, not modified in place."""
+        trials = self._make_tidy_trials()
+        before = trials.copy()
+        bbone.SessionLoader.apply_tidy_transformations(trials)
+        pd.testing.assert_frame_equal(trials, before)
+
+    def test_tidy_nan_probability_left_raises(self):
+        """A NaN in probabilityLeft indicates corrupted data and must raise ValueError."""
+        trials = self._make_tidy_trials()
+        trials.loc[2, 'probabilityLeft'] = np.nan
+        self.assertRaises(ValueError, bbone.SessionLoader.apply_tidy_transformations, trials)
 
     def test_load_iti(self):
         """Test for brainbox.io.one.load_iti function."""


### PR DESCRIPTION
added loading tidy trials tables functionality to the `SessionLoader` - default is previous ONE behavior, add method originally authored by Heberto from CatalystNeuro to convert the trials table to tidy format. Loading behavior of the SessionLoader can be modified by a kwarg, i.e. `session_loader.load_trials(style='tidy')` will load the trials table in tidy format