### PR TITLE
replace DLC with LP in data loading docs

### DIFF
--- a/examples/loading_data/loading_video_data.ipynb
+++ b/examples/loading_data/loading_video_data.ipynb
@@ -80,8 +80,8 @@
    "source": [
     "## More details\n",
     "* [Description of camera datasets](https://docs.google.com/document/d/1OqIqqakPakHXRAwceYLwFY9gOrm8_P62XIfCTnHwstg/edit#heading=h.yjwa7dpoipz)\n",
-    "* [Description of DLC pipeline in IBL](https://github.com/int-brain-lab/iblvideo#readme)\n",
-    "* [Description of DLC QC metrics](https://int-brain-lab.github.io/iblenv/_autosummary/ibllib.qc.dlc.html)\n",
+    "* [Description of pose estimation pipeline in IBL](https://github.com/int-brain-lab/iblvideo#readme)\n",
+    "* [Description of pose estimation QC metrics](https://int-brain-lab.github.io/iblenv/_autosummary/ibllib.qc.dlc.html)\n",
     "* [IBL video white paper](https://docs.google.com/document/u/1/d/e/2PACX-1vS2777bCbDmMre-wyeDr4t0jC-0YsV_uLtYkfS3h9zTwgC7qeMk-GUqxPqcY7ylH17I1Vo1nIuuj26L/pub)"
    ]
   },
@@ -92,7 +92,9 @@
    "source": [
     "## Useful modules\n",
     "* [brainbox.behavior.dlc](https://int-brain-lab.github.io/iblenv/_autosummary/brainbox.behavior.dlc.html)\n",
-    "* [ibllib.qc.dlc](https://int-brain-lab.github.io/iblenv/_autosummary/ibllib.qc.dlc.html)"
+    "* [ibllib.qc.dlc](https://int-brain-lab.github.io/iblenv/_autosummary/ibllib.qc.dlc.html)\n",
+    "\n",
+    "NOTE: the IBL video analysis pipeline now uses [Lightning Pose](https://lightning-pose.readthedocs.io/), but internal pose estimation modules are still named `dlc`."
    ]
   },
   {
@@ -107,9 +109,7 @@
    "cell_type": "markdown",
    "id": "8c09b09e",
    "metadata": {},
-   "source": [
-    "### Example 1: Filtering dlc features by likelihood threshold"
-   ]
+   "source": "### Example 1: Filtering pose estimation features by likelihood threshold"
   },
   {
    "cell_type": "code",
@@ -121,16 +121,15 @@
     "# Set values with likelihood below chosen threshold to NaN\n",
     "from brainbox.behavior.dlc import likelihood_threshold\n",
     "\n",
-    "dlc = likelihood_threshold(video_features['dlc'], threshold=0.9)"
+    "# threshold Lightning Pose predictions\n",
+    "poses = likelihood_threshold(video_features['lightningPose'], threshold=0.9)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "bd5a739e",
    "metadata": {},
-   "source": [
-    "### Example 2: Compute speed of dlc feature"
-   ]
+   "source": "### Example 2: Compute speed of pose features"
   },
   {
    "cell_type": "code",
@@ -143,8 +142,8 @@
     "\n",
     "# Compute the speed of the right paw\n",
     "feature = 'paw_r'\n",
-    "dlc_times = video_features['times']\n",
-    "paw_r_speed = get_speed(dlc, dlc_times, label, feature=feature)"
+    "pose_times = video_features['times']\n",
+    "paw_r_speed = get_speed(poses, pose_times, label, feature=feature)"
    ]
   },
   {


### PR DESCRIPTION
Current `ibllib` data loading docs still reference `"dlc"` pose estimates; this PR updates the docs to reference the updated `"lightningPose"` estimates.

I have also verified that the reference eid in the example does in fact contain Lightning Pose estimates.