### PR TITLE
Neuropixels synchronisation error detection

### DIFF
--- a/ibllib/ephys/sync_probes.py
+++ b/ibllib/ephys/sync_probes.py
@@ -45,7 +45,7 @@ def sync(ses_path, **kwargs):
         return version3B(ses_path, **kwargs)
 
 
-def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None, raise_on_anomaly=False):
+def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None, raise_on_anomaly=True):
     """
     From a session path with _spikeglx_sync arrays extracted, locate ephys files for 3A and
      outputs one sync.timestamps.probeN.npy file per acquired probe. By convention the reference
@@ -53,9 +53,13 @@ def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None, 
      Assumes the _spikeglx_sync datasets are already extracted from binary data
     :param ses_path:
     :param type: linear, exact or smooth
-    :param raise_on_anomaly: if True, raise SyncFrontsAnomaly when the sync_probe_front_times
-     tolerance check fails for a probe, instead of only logging it and continuing with
-     qc_all=False (default). No auto-switching between frame2ttl/right_camera is attempted.
+    :param raise_on_anomaly: if True (default), raise SyncFrontsAnomaly when the
+     sync_probe_front_times tolerance check fails for a probe, instead of only logging it and
+     continuing with qc_all=False. No auto-switching between frame2ttl/right_camera is attempted.
+     Defaults to True (unlike version3B's raise_on_anomaly, which defaults to False): 3A is a
+     legacy extraction path as of 2026-08-23 -- no ephys recording currently acquired uses 3A
+     hardware, so an anomaly here should be rare, and if one does occur, raising is the lesser
+     of the two evils versus letting a bad sync silently land in the database.
     :return: bool True on a a successful sync
     """
     ephys_files = spikeglx.glob_ephys_files(ses_path, ext='meta', bin_exists=False)

--- a/ibllib/ephys/sync_probes.py
+++ b/ibllib/ephys/sync_probes.py
@@ -9,7 +9,7 @@ import one.alf.exceptions
 from iblutil.util import Bunch
 import spikeglx
 
-from ibllib.exceptions import Neuropixel3BSyncFrontsNonMatching
+from ibllib.exceptions import Neuropixel3BSyncFrontsNonMatching, SyncFrontsAnomaly
 from ibllib.io.extractors.ephys_fpga import get_sync_fronts, get_ibl_sync_map
 
 _logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def sync(ses_path, **kwargs):
         return version3B(ses_path, **kwargs)
 
 
-def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None):
+def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None, raise_on_anomaly=False):
     """
     From a session path with _spikeglx_sync arrays extracted, locate ephys files for 3A and
      outputs one sync.timestamps.probeN.npy file per acquired probe. By convention the reference
@@ -53,6 +53,9 @@ def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None):
      Assumes the _spikeglx_sync datasets are already extracted from binary data
     :param ses_path:
     :param type: linear, exact or smooth
+    :param raise_on_anomaly: if True, raise SyncFrontsAnomaly when the sync_probe_front_times
+     tolerance check fails for a probe, instead of only logging it and continuing with
+     qc_all=False (default). No auto-switching between frame2ttl/right_camera is attempted.
     :return: bool True on a a successful sync
     """
     ephys_files = spikeglx.glob_ephys_files(ses_path, ext='meta', bin_exists=False)
@@ -85,9 +88,11 @@ def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None):
             d['times'].append(sync['times'][isync])
         return d
 
+    aux_used = 'frame2ttl'
     d = get_sync_fronts('frame2ttl')
     if not d:
         _logger.warning('Ephys sync: frame2ttl not detected on both probes, using camera sync')
+        aux_used = 'right_camera'
         d = get_sync_fronts('right_camera')
         if not min([t[0] for t in d['times']]) > 0.2:
             raise ValueError('Cameras started before ephys, no sync possible')
@@ -110,11 +115,16 @@ def version3A(ses_path, display=True, type='smooth', tol=2.1, probe_names=None):
         else:
             timestamps, qc = sync_probe_front_times(d.times[:, ind], d.times[:, iref], sr, display=display, type=type, tol=tol)
             qc_all &= qc
+            if not qc:
+                probe_name = ephys_file.path.parts[-1]
+                _logger.error(f'{ses_path} probe {probe_name}: sync anomaly using aux channel "{aux_used}"')
+                if raise_on_anomaly:
+                    raise SyncFrontsAnomaly(f'{ses_path} probe {probe_name}: aux channel "{aux_used}"')
         out_files = _save_timestamps_npy(ephys_file, timestamps, sr)
     return qc_all, out_files
 
 
-def version3B(ses_path, display=True, type=None, tol=2.5, probe_names=None):
+def version3B(ses_path, display=True, type=None, tol=2.5, probe_names=None, raise_on_anomaly=False):
     """
     From a session path with _spikeglx_sync arrays extracted, locate ephys files for 3A and
      outputs one sync.timestamps.probeN.npy file per acquired probe. By convention the reference
@@ -124,6 +134,9 @@ def version3B(ses_path, display=True, type=None, tol=2.5, probe_names=None):
     :param type: linear, exact or smooth
     :param probe_names: by default will rglob all probes in the directory. If specified, this will filter
      the probes on which to perform the synchronisation, defaults to None, optional
+    :param raise_on_anomaly: if True, raise SyncFrontsAnomaly when a classifiable raw-pulse
+     pathology (dropped_edges / duplicate_burst / single_edge_glitch) is found on the probe or
+     reference channel, instead of only logging it and continuing with qc_all=False (default).
     :return: None
     """
     DEFAULT_TYPE = 'smooth'
@@ -168,6 +181,13 @@ def version3B(ses_path, display=True, type=None, tol=2.5, probe_names=None):
         if not qcdiff:
             qc_all = False
             type_probe = type or 'exact'
+            # _check_diff_3b filters to rising edges only (polarities == 1); match that here so
+            # the diagnosis is computed on the same front subset that triggered the anomaly.
+            label = (classify_sync_anomaly(sync_probe.times[sync_probe.polarities == 1])
+                     or classify_sync_anomaly(sync_nidq.times[sync_nidq.polarities == 1]))
+            _logger.error(f'{ses_path} probe {ef.path.parts[-1]}: sync anomaly detected: {label}')
+            if raise_on_anomaly and label is not None:
+                raise SyncFrontsAnomaly(f'{ses_path} probe {ef.path.parts[-1]}: {label}')
         else:
             type_probe = type or DEFAULT_TYPE
         timestamps, qc = sync_probe_front_times(
@@ -270,6 +290,59 @@ def _save_timestamps_npy(ephys_file, tself_tref, sr):
     timestamps[:, 0] *= np.float64(sr)
     np.save(file_ts, timestamps)
     return [file_sync, file_ts]
+
+
+def classify_sync_anomaly(times, block=20, burst_factor=0.2, glitch_abs_thresh=0.005):
+    """
+    Classify a raw-pulse pathology from a single channel's front times, independent of
+    whichever knot representation ('smooth'/'exact') ends up chosen downstream.
+
+    Three independent checks, in order of precedence:
+
+    - ``dropped_edges``: a sustained pulse-rate change (block-median inter-pulse interval
+      drifts more than 30% from the global median, and stays drifted through to the end --
+      not a transient blip). Typically real edges dropped partway through the recording.
+    - ``duplicate_burst``: an inter-pulse interval far shorter than nominal (< ``burst_factor``
+      times the median). Typically a bounced/double-triggered edge.
+    - ``single_edge_glitch``: one isolated interval deviating from the median by more than
+      ``glitch_abs_thresh`` in absolute terms (not relative -- real cases found this way
+      ranged from 2.4% to 28% of the nominal period, too variable for a relative threshold).
+
+    Parameters
+    ----------
+    times : array_like
+        Front times (seconds) of a single channel, one polarity.
+    block : int
+        Number of consecutive intervals averaged per block for the `dropped_edges` check.
+    burst_factor : float
+        Fraction of the median interval below which an interval is flagged as a burst.
+    glitch_abs_thresh : float
+        Absolute deviation (seconds) from the median interval above which a single interval
+        is flagged as an isolated glitch.
+
+    Returns
+    -------
+    str or None
+        One of 'dropped_edges', 'duplicate_burst', 'single_edge_glitch', or None (clean).
+    """
+    dt = np.diff(np.asarray(times))
+    med = np.median(dt)
+    if med <= 0:
+        return None
+
+    if dt.size >= block * 3:
+        block_med = np.array([np.median(dt[i:i + block]) for i in range(0, dt.size - block, block)])
+        bad = np.where(np.abs(block_med - med) / med > 0.3)[0]
+        if bad.size > 0 and bad[-1] >= len(block_med) - 2:  # sustained to the end, not a blip
+            return 'dropped_edges'
+
+    if np.any(dt < burst_factor * med):
+        return 'duplicate_burst'
+
+    if np.max(np.abs(dt - med)) > glitch_abs_thresh:
+        return 'single_edge_glitch'
+
+    return None
 
 
 def _check_diff_3b(sync):

--- a/ibllib/exceptions.py
+++ b/ibllib/exceptions.py
@@ -27,6 +27,14 @@ class Neuropixel3BSyncFrontsNonMatching(IblError):
     )
 
 
+class SyncFrontsAnomaly(IblError):
+    explanation = (
+        ' The raw sync pulse fronts show a specific, classifiable pathology: dropped edges, '
+        'a duplicate/bounced burst, an isolated mistimed edge, or an unreliable 3A reference '
+        'channel. Raised only when the caller opted in via raise_on_anomaly=True.'
+    )
+
+
 class NvidiaDriverNotReady(IblError):
     explanation = (
         'Nvidia driver does not respond. This usually means the GPU is inaccessible '

--- a/ibllib/exceptions.py
+++ b/ibllib/exceptions.py
@@ -31,7 +31,8 @@ class SyncFrontsAnomaly(IblError):
     explanation = (
         ' The raw sync pulse fronts show a specific, classifiable pathology: dropped edges, '
         'a duplicate/bounced burst, an isolated mistimed edge, or an unreliable 3A reference '
-        'channel. Raised only when the caller opted in via raise_on_anomaly=True.'
+        'channel. Raised only when the caller opted in via raise_on_anomaly=True. See '
+        'https://github.com/int-brain-lab/lfpack/issues/8 for the original investigation.'
     )
 
 

--- a/ibllib/tests/test_sync_probes.py
+++ b/ibllib/tests/test_sync_probes.py
@@ -1,0 +1,150 @@
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+from iblutil.util import Bunch
+
+from ibllib.ephys import sync_probes
+from ibllib.exceptions import SyncFrontsAnomaly
+
+
+class TestClassifySyncAnomaly(unittest.TestCase):
+    """classify_sync_anomaly on synthetic single-channel front times."""
+
+    def _regular_times(self, n=200, period=1.0):
+        return np.arange(n, dtype=float) * period
+
+    def test_clean_returns_none(self):
+        times = self._regular_times()
+        self.assertIsNone(sync_probes.classify_sync_anomaly(times))
+
+    def test_dropped_edges(self):
+        # sustained rate doubling for the last ~15% of pulses, matching the audit's
+        # dropped_edges signature (probe free-runs at ~2x nominal rate past a truncation point).
+        n_normal = 170
+        n_fast = 30
+        normal = np.arange(n_normal, dtype=float)
+        fast = normal[-1] + np.arange(1, n_fast + 1) * 0.5
+        times = np.r_[normal, fast]
+        self.assertEqual(sync_probes.classify_sync_anomaly(times), 'dropped_edges')
+
+    def test_duplicate_burst(self):
+        # one interval far shorter than nominal -- a bounced/double-triggered edge.
+        times = self._regular_times()
+        times[100] = times[99] + 1e-3  # squeeze pulse 100 right next to pulse 99
+        self.assertEqual(sync_probes.classify_sync_anomaly(times), 'duplicate_burst')
+
+    def test_single_edge_glitch(self):
+        # one isolated edge mistimed by a large absolute amount, but not a burst
+        # (deviation stays well above the 0.2x-median burst threshold).
+        times = self._regular_times()
+        times[100:] += 0.05  # 50ms one-off shift, well past glitch_abs_thresh (5ms)
+        self.assertEqual(sync_probes.classify_sync_anomaly(times), 'single_edge_glitch')
+
+    def test_too_few_points_is_clean(self):
+        self.assertIsNone(sync_probes.classify_sync_anomaly(np.array([0.0, 1.0, 2.0])))
+
+
+def _make_ephys_file(path, ap):
+    return Bunch({'path': Path(path), 'ap': Path(ap)})
+
+
+class TestVersion3BAnomalyRaising(unittest.TestCase):
+    """version3B(raise_on_anomaly=...) wiring, with all file I/O mocked out."""
+
+    def setUp(self):
+        n = 200
+        nidq_times = np.arange(n, dtype=float)
+        probe_times = nidq_times.copy()
+        probe_times[100] = probe_times[99] + 1e-3  # duplicate_burst on the probe channel
+
+        nidq_ef = _make_ephys_file('nidq', 'nidq.ap.meta')
+        nidq_ef['nidq'] = True
+        nidq_ef['sync'] = Bunch({
+            'channels': np.full(n, 6),
+            'times': nidq_times,
+            'polarities': np.ones(n, dtype=int),
+        })
+        probe_ef = _make_ephys_file('probe00', 'probe00.ap.meta')
+        probe_ef['sync'] = Bunch({
+            'channels': np.full(n, 6),
+            'times': probe_times,
+            'polarities': np.ones(n, dtype=int),
+        })
+        self.ephys_files = [nidq_ef, probe_ef]
+
+        self.patches = [
+            mock.patch.object(sync_probes.spikeglx, 'glob_ephys_files', return_value=self.ephys_files),
+            mock.patch.object(sync_probes.alfio, 'load_object', side_effect=lambda path, *a, **k: (
+                nidq_ef['sync'] if path == nidq_ef.path else probe_ef['sync']
+            )),
+            mock.patch.object(sync_probes, 'get_ibl_sync_map', return_value={'imec_sync': 6}),
+            mock.patch.object(sync_probes, '_get_sr', return_value=30000.0),
+            mock.patch.object(sync_probes, '_save_timestamps_npy', return_value=['fake_sync.npy', 'fake_timestamps.npy']),
+        ]
+        for p in self.patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_raises_when_opted_in(self):
+        with self.assertRaises(SyncFrontsAnomaly):
+            sync_probes.version3B('fake_session', display=False, raise_on_anomaly=True)
+
+    def test_does_not_raise_by_default(self):
+        qc_all, out_files = sync_probes.version3B('fake_session', display=False)
+        self.assertFalse(qc_all)
+        self.assertTrue(len(out_files) > 0)
+
+    def test_does_not_raise_when_explicitly_disabled(self):
+        qc_all, out_files = sync_probes.version3B('fake_session', display=False, raise_on_anomaly=False)
+        self.assertFalse(qc_all)
+
+
+class TestVersion3AAnomalyRaising(unittest.TestCase):
+    """version3A(raise_on_anomaly=...) wiring, with sync_probe_front_times mocked to fail qc."""
+
+    def setUp(self):
+        n = 200
+        ref_times = np.arange(n, dtype=float)
+        probe_times = ref_times.copy()
+
+        # .ap.parent (not .path) is what version3A's inner get_sync_fronts passes to
+        # alfio.load_object -- give each probe its own parent directory so they resolve
+        # to distinct fixture entries below.
+        ephys_files = [
+            _make_ephys_file('probe00', 'probe00/probe00.ap.meta'),
+            _make_ephys_file('probe01', 'probe01/probe01.ap.meta'),
+        ]
+        sync_by_path = {
+            ephys_files[0].ap.parent: Bunch({'channels': np.full(n, 2), 'times': ref_times}),
+            ephys_files[1].ap.parent: Bunch({'channels': np.full(n, 2), 'times': probe_times}),
+        }
+
+        self.patches = [
+            mock.patch.object(sync_probes.spikeglx, 'glob_ephys_files', return_value=ephys_files),
+            mock.patch.object(sync_probes, 'alfio'),
+            mock.patch.object(sync_probes, 'get_ibl_sync_map', return_value={'frame2ttl': 2}),
+            mock.patch.object(sync_probes, '_get_sr', return_value=30000.0),
+            mock.patch.object(sync_probes, '_save_timestamps_npy', return_value=['fake_sync.npy', 'fake_timestamps.npy']),
+            # force the tolerance check to fail regardless of the (irrelevant here) input data
+            mock.patch.object(sync_probes, 'sync_probe_front_times',
+                               return_value=(np.array([[0.0, 0.0], [1.0, 1.0]]), False)),
+        ]
+        for p in self.patches:
+            mocked = p.start()
+            self.addCleanup(p.stop)
+        sync_probes.alfio.load_object.side_effect = lambda path, *a, **k: sync_by_path[path]
+
+    def test_raises_when_opted_in(self):
+        with self.assertRaises(SyncFrontsAnomaly):
+            sync_probes.version3A('fake_session', display=False, raise_on_anomaly=True)
+
+    def test_does_not_raise_by_default(self):
+        qc_all, out_files = sync_probes.version3A('fake_session', display=False)
+        self.assertFalse(qc_all)
+        self.assertTrue(len(out_files) > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ibllib/tests/test_sync_probes.py
+++ b/ibllib/tests/test_sync_probes.py
@@ -140,8 +140,14 @@ class TestVersion3AAnomalyRaising(unittest.TestCase):
         with self.assertRaises(SyncFrontsAnomaly):
             sync_probes.version3A('fake_session', display=False, raise_on_anomaly=True)
 
-    def test_does_not_raise_by_default(self):
-        qc_all, out_files = sync_probes.version3A('fake_session', display=False)
+    def test_raises_by_default(self):
+        # raise_on_anomaly defaults to True for version3A (unlike version3B): 3A is a legacy
+        # extraction path, so an anomaly here is unlikely and worth failing loudly on.
+        with self.assertRaises(SyncFrontsAnomaly):
+            sync_probes.version3A('fake_session', display=False)
+
+    def test_does_not_raise_when_explicitly_disabled(self):
+        qc_all, out_files = sync_probes.version3A('fake_session', display=False, raise_on_anomaly=False)
         self.assertFalse(qc_all)
         self.assertTrue(len(out_files) > 0)
 


### PR DESCRIPTION
## Summary
- `version3B` already sets `qc_all=False` when `_check_diff_3b`'s 150ppm burst check fails, but that signal was unlabeled and unenforced — a probe hitting a dropped-edge, duplicate-burst, or isolated-glitch pathology just silently fell back to `type='exact'` 
- New `classify_sync_anomaly()` labels which of the three it is, from the raw front times alone. Both `version3A`/`version3B` now log the label whenever their existing QC check fails, and accept a new opt-in `raise_on_anomaly=False` kwarg that raises a new `SyncFrontsAnomaly` exception instead of continuing silently.
- Default behavior is unchanged for every existing caller — this is detection + an opt-in exception, not a change to the sync algorithm, fit types, or 3A's frame2ttl/right_camera precedence.
- Found via a real audit of 20 IBL probes with flagged sync issues ([lfpack#8](https://github.com/int-brain-lab/lfpack/issues/8)) — 11 had one of these three defects (plus one `irregular_3A_reference` case, out of scope here).

## Test plan
- [x] New `ibllib/tests/test_sync_probes.py`: 5 unit tests for `classify_sync_anomaly` (clean + the three defect signatures), 5 wiring tests for `version3A`/`version3B`'s `raise_on_anomaly` (raises when `True`, doesn't when `False`/default) — all file I/O mocked, no external dataset needed.
- [x] `ibllib/tests/test_ephys.py` — unaffected (same pre-existing unrelated network-auth failure as before this change).
- [x] `ibllib/tests/integration/test_ephys_synchronization.py` — still just skips (no external dataset in this environment), confirmed it doesn't error on collection.
- [x] ruff clean.