### PR TITLE
Migrate packaging to pyproject.toml - switch to uv build

### DIFF
--- a/ibllib/__init__.py
+++ b/ibllib/__init__.py
@@ -1,10 +1,12 @@
 """Library implementing the International Brain Laboratory data pipeline."""
 
+import importlib.metadata
 import logging
 import warnings
 import os
 
-__version__ = '3.5.dev+ci1'
+__version__ = importlib.metadata.version('ibllib')  # managed through pyproject.toml, section [project]
+
 warnings.filterwarnings('always', category=DeprecationWarning, module='ibllib')
 
 # if this becomes a full-blown library we should let the logging configuration to the discretion of the dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["setuptools>=64"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build<0.13.0"]
+build-backend = "uv_build"
 
 [project]
 name = "ibllib"
+version = "3.5.dev+ci1"
 description = "IBL libraries"
 readme = "README.md"
 license = "MIT"
@@ -12,7 +13,6 @@ authors = [
     {name = "IBL Staff"},
 ]
 requires-python = ">=3.10"
-dynamic = ["version"]
 dependencies = [
     "ONE-api>=3.4.2",
     "boto3",
@@ -68,19 +68,25 @@ dev = [
     "ruff",
 ]
 
-[tool.setuptools.dynamic]
-version = {attr = "ibllib.__version__"}
-
-[tool.setuptools]
-include-package-data = true
-
-[tool.setuptools.packages.find]
-exclude = ["scratch"]
-namespaces = false
-
 [tool.uv]
 required-environments = [
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
     "sys_platform == 'win32' and platform_machine == 'AMD64'",
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
+]
+
+[tool.uv.build-backend]
+module-name = ["brainbox", "ibllib", "examples"]
+module-root = ""
+source-include = [
+    "ibllib/io/extractors/extractor_types.json",
+    "ibllib/io/extractors/task_extractor_map.json",
+    "brainbox/tests/wheel_test.p",
+    "brainbox/tests/fixtures/**",
+    "ibllib/qc/reference/**",
+    "ibllib/tests/extractors/data/**",
+    "ibllib/io/extractors/ephys_sessions/**",
+    "ibllib/io/extractors/mesoscope/**",
+    "ibllib/tests/fixtures/**",
+    "oneibl/tests/fixtures/**",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -861,6 +861,7 @@ wheels = [
 
 [[package]]
 name = "ibllib"
+version = "3.5.dev0+ci1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
here's how to have several modules in a package.

please double-check if the included package data is correct (i.e., non-python files). See:
- https://setuptools.pypa.io/en/latest/userguide/datafiles.html
- https://docs.astral.sh/uv/concepts/build-backend/#file-inclusion-and-exclusion