### PR TITLE
Fix: IntegrationTest.required_files was never actually enforced

### DIFF
--- a/ibllib/tests/base.py
+++ b/ibllib/tests/base.py
@@ -173,7 +173,7 @@ class IntegrationTest(unittest.TestCase):
                             self.data_path.is_dir() and
                             any(self.data_path.glob('Subjects_init')))
             if self.required_files:
-                data_present &= all(map(self.data_path.glob, self.required_files))
+                data_present &= all(any(self.data_path.glob(pattern)) for pattern in self.required_files)
             if not data_present:
                 raise FileNotFoundError(f'Invalid data root folder {self.data_path.absolute()}\n\t'
                                         'must contain a "Subjects_init" folder.')


### PR DESCRIPTION
## Summary

`IntegrationTest` lets a subclass declare `required_files` and is documented to raise `FileNotFoundError` when they are absent. The check was written so that it **always evaluated to `True`**, so declaring `required_files` gave no protection: tests with missing or misspelled data ran anyway and failed later, somewhere unrelated, with no hint that the data was the problem.

## Root cause

In `ibllib/tests/base.py`, `IntegrationTest.__init__`:

```python
if self.required_files:
    data_present &= all(map(self.data_path.glob, self.required_files))  # always True
```

`map(self.data_path.glob, self.required_files)` yields one **lazy generator per pattern**, not one boolean per pattern. Generators are unconditionally truthy, so `all(...)` is `True` regardless of the patterns, and `&=` never clears the flag. The line directly above gets it right by wrapping the glob in `any()`.

## Fix

```diff
-                data_present &= all(map(self.data_path.glob, self.required_files))
+                data_present &= all(any(self.data_path.glob(pattern)) for pattern in self.required_files)
```

Each glob is now consumed by `any()`, yielding a real boolean per pattern — mirroring the correct idiom used one line above for `Subjects_init`.

## Impact

- **ibllib unit suite:** unchanged — nothing in it declares `required_files`.
- **Downstream integration suites (`iblscripts`, `mpci`):** expect **new** failures once the check starts working. That is the intended effect, but it means some stale `required_files` declarations that have been passing only because the check was inert will now surface and need a sweep.

## Provenance

Introduced in `ee3acf7e` ("MPCI Package", #1125) — the commit that added the `INTEGRATION_DATA_DIR` / writable-mirror mechanism. The check has therefore never worked; there is no regression to bisect.

## Verification

Reproduction (no integration data needed):

```python
from pathlib import Path
root = Path.cwd()
print(all(map(root.glob, ['does/not/exist'])))            # True  (bug)
print(all(any(root.glob(p)) for p in ['does/not/exist'])) # False (fixed)
```

## Not addressed here

Several adjacent defects in the same class were found during review (collection-time raise vs. skip, `_writable_scope='test'` bypass, dropped `isdir` guard on the class skip, silent mirroring of missing entries, etc.). They are **out of scope** for this one-line correctness fix and left for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
