### PR TITLE
Fix IntegrationTest data-root check: skip instead of aborting collection, and actually enforce required_files

### DIFF
--- a/ibllib/tests/base.py
+++ b/ibllib/tests/base.py
@@ -25,6 +25,7 @@ _logger = logging.getLogger('ibllib')
 
 class TimeLoggingTestResult(TextTestResult):
     """A class to record test durations"""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_timings = []
@@ -47,6 +48,7 @@ class TimeLoggingTestResult(TextTestResult):
 
 class TimeLoggingTestRunner(TextTestRunner):
     """A class that prints a list of the slowest tests to the output stream"""
+
     def __init__(self, slow_test_threshold=0.3, *args, **kwargs):
         self.slow_test_threshold = slow_test_threshold
         super().__init__(resultclass=TimeLoggingTestResult, *args, **kwargs)
@@ -95,7 +97,7 @@ class _DataPathDescriptor:
 
 @unittest.skipUnless(
     INTEGRATION_DATA_DIR and os.path.isdir(INTEGRATION_DATA_DIR),
-    "Integration data not available (set INTEGRATION_DATA_DIR to enable).",
+    'Integration data not available (set INTEGRATION_DATA_DIR to enable).',
 )
 class IntegrationTest(unittest.TestCase):
     """Base class for tests that require S3 integration data.
@@ -148,7 +150,20 @@ class IntegrationTest(unittest.TestCase):
         super().tearDownClass()
 
     def setUp(self):
+        """Validate the data root and, if required, build a per-test writable mirror.
+
+        The data-root validation lives here rather than in __init__ because __init__ runs
+        during test construction (collection), before @skipUnless is consulted; raising there
+        would abort collection of the whole module. Subclasses overriding setUp must call
+        super().setUp() for the skip to take effect.
+        """
         super().setUp()
+        if INTEGRATION_DATA_DIR and type(self)._writable_tempdir is None and self._writable_scope != 'test':
+            data_present = self.data_path.exists() and self.data_path.is_dir() and any(self.data_path.glob('Subjects_init'))
+            if self.required_files:
+                data_present &= all(any(self.data_path.glob(pattern)) for pattern in self.required_files)
+            if not data_present:
+                self.skipTest(f'Invalid data root folder {self.data_path.absolute()}: missing "Subjects_init" or required_files')
         if not INTEGRATION_DATA_WRITABLE and self.required_files and self._writable_scope == 'test':
             _, self._writable_tempdir = make_sym_links(self._required_sources())
 
@@ -167,16 +182,6 @@ class IntegrationTest(unittest.TestCase):
         :param data_path: The data root path to the integration data directory
         """
         super().__init__(*args, **kwargs)
-
-        if type(self)._writable_tempdir is None and self._writable_scope != 'test':
-            data_present = (self.data_path.exists() and
-                            self.data_path.is_dir() and
-                            any(self.data_path.glob('Subjects_init')))
-            if self.required_files:
-                data_present &= all(map(self.data_path.glob, self.required_files))
-            if not data_present:
-                raise FileNotFoundError(f'Invalid data root folder {self.data_path.absolute()}\n\t'
-                                        'must contain a "Subjects_init" folder.')
 
     @classmethod
     def default_data_root(cls):
@@ -233,8 +238,10 @@ def list_current_sessions(one=None):
     :param one: An ONE object for fetching session eid from path
     :return: Set of integration session eids
     """
+
     def not_null(itr):
         return filter(lambda x: x is not None, itr)
+
     one = one or ONE()
     root = IntegrationTest.default_data_root()
     folders = set(get_session_path(x[0]) for x in os.walk(root))
@@ -250,6 +257,7 @@ def disable_log(level=logging.CRITICAL, restore_level=None, quiet=False):
     :param quiet: If false the fact that the log is disabled will be printed
     :return:
     """
+
     def decorator(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):
@@ -261,7 +269,9 @@ def disable_log(level=logging.CRITICAL, restore_level=None, quiet=False):
                 print('**Log re-enabled**')
             logging.disable(restore_level or logging.NOTSET)
             return output
+
         return wrapper
+
     return decorator
 
 
@@ -275,7 +285,7 @@ def _get_test_db():
             'base_url': 'https://test.alyx.internationalbrainlab.org',
             'username': 'test_user',
             'password': 'TapetesBloc18',
-            'silent': True
+            'silent': True,
         }
 
 


### PR DESCRIPTION
## Summary

Fixes two related defects in `IntegrationTest` (`ibllib/tests/base.py`), both in the data-root validation. They live in the same block, so they're fixed together.

## Bug 1 — collection aborts instead of skipping (the discovery failure)

`IntegrationTest` is decorated `@unittest.skipUnless(INTEGRATION_DATA_DIR ...)`, but the data-root validation that raised `FileNotFoundError` lived in `__init__`. `__init__` runs during test **construction** (unittest discovery / pytest collection), *before* the skip is consulted — and `skipUnless` only wraps test *execution*, so it can't intercept it.

Net effect: pointing `INTEGRATION_DATA_DIR` at any directory that lacks a `Subjects_init` folder (e.g. a live ONE cache) raised mid-collection and **aborted discovery of the entire module** — not just the one class — even though the class is supposed to be skippable.

**Fix:** move the validation out of `__init__` into `setUp`, and call `self.skipTest(...)` instead of raising. The guard condition is unchanged, so semantics are preserved; the failure mode now matches what `skipUnless` advertises — a skip, confined to the affected test, never a collection crash.

## Bug 2 — `required_files` was never enforced

```python
data_present &= all(map(self.data_path.glob, self.required_files))  # always True
```

`map(self.data_path.glob, ...)` yields one lazy generator per pattern; generators are unconditionally truthy, so `all(...)` was always `True` and `required_files` gave no protection. Tests with missing/misspelled data ran anyway and failed later, unrelated.

**Fix:** consume each glob with `any()`, mirroring the correct idiom already used one line above for `Subjects_init`:

```python
data_present &= all(any(self.data_path.glob(pattern)) for pattern in self.required_files)
```

## Verification

- `INTEGRATION_DATA_DIR` set to a dir without `Subjects_init` → the test now reports **skipped**, and collection of the rest of the module is unaffected (previously a collection error).
- Valid `Subjects_init` root → constructs and runs normally.
- A subclass declaring a missing `required_files` entry → skipped (previously ran regardless).

## Notes

- With `required_files` now actually enforced, any stale declarations in downstream suites that passed only because the check was inert will start (correctly) skipping.
- Because validation now lives in `setUp`, subclasses overriding `setUp` must call `super().setUp()` for the skip to take effect (was already required for `_writable_scope='test'` classes; documented in the new `setUp` docstring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
